### PR TITLE
Upgrade checkout to v1.1.0 to better support scripting git.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: "test-local"
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'releases/*'
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@master
+    - uses: ./
+    - run: git ls-remote --tags origin

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# checkout
+<p align="center">
+  <a href="https://github.com/actions/checkout"><img alt="GitHub Actions status" src="https://github.com/actions/checkout/workflows/test-local/badge.svg"></a>
+</p>
+
+# Checkout
 
 This action checks out your repository to `$GITHUB_WORKSPACE`, so that your workflow can access the contents of your repository.
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Basic:
 
 ```yaml
 steps:
-- uses: actions/checkout@v1.0.0
-- uses: actions/setup-node@master
+- uses: actions/checkout@v1
+- uses: actions/setup-node@v1
   with:
     node-version: 10.x 
 - run: npm install
@@ -25,14 +25,14 @@ By default, the branch or tag ref that triggered the workflow will be checked ou
 
 Checkout different branch from the workflow repository:
 ```yaml
-- uses: actions/checkout@v1.0.0
+- uses: actions/checkout@v1
   with:
     ref: some-branch
 ```
 
 Checkout different private repository:
 ```yaml
-- uses: actions/checkout@v1.0.0
+- uses: actions/checkout@v1
   with:
     repository: myAccount/myRepository
     ref: refs/heads/release
@@ -41,7 +41,7 @@ Checkout different private repository:
 
 Checkout private submodules:
 ```yaml
-- uses: actions/checkout@v1.0.0
+- uses: actions/checkout@v1
   with:
     submodules: recursive
     token: ${{ secrets.GitHub_PAT }} // `GitHub_PAT` is a secret contains your PAT.
@@ -53,7 +53,7 @@ For more details, see [Contexts and expression syntax for GitHub Actions](https:
 
 # Changelog
 
-## master (unreleased)
+## v1.1.0 (unreleased)
 - Persist `with.token` or `${{ github.token }}` into checkout repository's git config as `http.https://github.com/.extraheader=AUTHORIZATION: basic ***` to better support scripting git
 
 # License

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Checkout private submodules:
 
 For more details, see [Contexts and expression syntax for GitHub Actions](https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions) and [Creating and using secrets (encrypted variables)](https://help.github.com/en/articles/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables)
 
+# Changelog
+
+## master (unreleased)
+- Persist `with.token` or `${{ github.token }}` into checkout repository's git config as `http.https://github.com/.extraheader=AUTHORIZATION: basic ***` to better support scripting git
+
 # License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Basic:
 
 ```yaml
 steps:
-- uses: actions/checkout@master
+- uses: actions/checkout@v1.0.0
 - uses: actions/setup-node@master
   with:
     node-version: 10.x 
@@ -21,15 +21,35 @@ steps:
 - run: npm test
 ```
 
-By default, the branch or tag ref that triggered the workflow will be checked out. If you wish to check out a different branch, specify that using `with.ref`:
+By default, the branch or tag ref that triggered the workflow will be checked out, `${{ github.token }}` will be used for any Git server authentication. If you wish to check out a different branch, a different repository or use different token to checkout, specify that using `with.ref`, `with.repository` and `with.token`:
 
+Checkout different branch from the workflow repository:
 ```yaml
-- uses: actions/checkout@master
+- uses: actions/checkout@v1.0.0
   with:
     ref: some-branch
 ```
 
-For more details, see [Contexts and expression syntax for GitHub Actions](https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions)
+Checkout different private repository:
+```yaml
+- uses: actions/checkout@v1.0.0
+  with:
+    repository: myAccount/myRepository
+    ref: refs/heads/release
+    token: ${{ secrets.GitHub_PAT }} // `GitHub_PAT` is a secret contains your PAT.
+```
+
+Checkout private submodules:
+```yaml
+- uses: actions/checkout@v1.0.0
+  with:
+    submodules: recursive
+    token: ${{ secrets.GitHub_PAT }} // `GitHub_PAT` is a secret contains your PAT.
+```
+> - `with.token` will be used as `Basic` authentication header for https requests talk to https://github.com from `git(.exe)`, ensure those private submodules are configured via `https` not `ssh`.
+> - `${{ github.token }}` only has permission to the workflow triggering repository. If the repository contains any submodules that comes from private repository, you will have to add your PAT as secret and use the secret in `with.token` to make `checkout` action work.
+
+For more details, see [Contexts and expression syntax for GitHub Actions](https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions) and [Creating and using secrets (encrypted variables)](https://help.github.com/en/articles/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables)
 
 # License
 

--- a/action.yml
+++ b/action.yml
@@ -20,4 +20,4 @@ inputs:
     description: 'Optional path to check out source code'  
 runs:
   # Plugins live on the runner and are only available to a certain set of first party actions.
-  plugin: 'checkout'
+  plugin: 'checkoutV1_1'


### PR DESCRIPTION
https://github.com/github/dreamlifter/issues/1297

Checkout will persist the git credential into the repository git config file.

If the token has write-access to the repository, workflow user can use
```yaml
- run: |
     git commit -am "changes"
     git push
```
to push the change back to the repository without dealing with git authentication.