### PR TITLE
Fix checkout head commit of PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Refer [here](https://github.com/actions/checkout/blob/v1/README.md) for previous
 ```yaml
 - uses: actions/checkout@v2-beta
   with:
-    ref: ${{ github.event.after }}
+    ref: ${{ github.event.pull_request.head.sha }}
 ```
 
 # License


### PR DESCRIPTION
`github.event.after` fails when Pull Request has just been created. At that time, `after` or `before` commit sha's do not exist. They exist during PR `synchronize` action.

Whereas `github.event.pull_request.head.sha` will work for both PR `opened` action as well as PR `synchronize` action.

Ref: #61 