### PR TITLE
Defaults to the default branch of the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Refer [here](https://github.com/actions/checkout/blob/v1/README.md) for previous
 
     # The branch, tag or SHA to checkout. When checking out the repository that
     # triggered a workflow, this defaults to the reference or SHA for that event.
-    # Otherwise, defaults to `master`.
+    # Otherwise, defaults to the default branch of the repository.
     ref: ''
 
     # Auth token used to fetch the repository. The token is stored in the local git

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: >
       The branch, tag or SHA to checkout. When checking out the repository that
       triggered a workflow, this defaults to the reference or SHA for that
-      event.  Otherwise, defaults to `master`.
+      event.  Otherwise, defaults to the default branch of the repository.
   token:
     description: >
       Auth token used to fetch the repository. The token is stored in the local


### PR DESCRIPTION
The README states:

> The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event.
> Otherwise, defaults to `master`.

But it appears the default is the default branch of the repository.

Or is just that a schedule event triggers the workflow from the default branch?