### PR TITLE
Handle submodules with SSH URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ jobs:
 - name: Checkout submodules
   shell: bash
   run: |
-    git config --global url."https://github.com/".insteadOf "git@github.com:"
+    # If your submodules are configured to use SSH instead of HTTPS please uncomment the following line
+    # git config --global url."https://github.com/".insteadOf "git@github.com:"
     auth_header="$(git config --local --get http.https://github.com/.extraheader)"
     git submodule sync --recursive
     git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ jobs:
 - name: Checkout submodules
   shell: bash
   run: |
+    git config --global url."https://github.com/".insteadOf "git@github.com:"
     auth_header="$(git config --local --get http.https://github.com/.extraheader)"
     git submodule sync --recursive
     git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1


### PR DESCRIPTION
This is just a documentation change, explaining how to fix submodules that are configured to use SSH URLs instead of HTTPS URLs. Spent a while banging my head on the wall and hope this saves someone else the pain.

This is helpful for teams that use the SSH protocol for local development so don't want to change the mechanism that pulls in the submodules.