### PR TITLE
revise ADR: convert SSH URL to HTTPS

### DIFF
--- a/adrs/0153-checkout-v2.md
+++ b/adrs/0153-checkout-v2.md
@@ -239,6 +239,8 @@ submodules scenarios: recursive, non-recursive, relative submodule paths.
 
 When fetching submodules, follow the `fetch-depth` settings.
 
+Also when fetching submodules, if the `ssh-key` input is not provided then convert SSH URLs to HTTPS: `-c url."https://github.com/".insteadOf "git@github.com:"`
+
 Credentials will be persisted in the submodules local git config too.
 
 ### Port to typescript


### PR DESCRIPTION
This change converts SSH URLs to HTTPS when an SSH key is not supplied.

Related to https://github.com/actions/checkout/issues/116#issuecomment-595472358