### PR TITLE
Remove submodules from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,6 @@ Refer [here](https://github.com/actions/checkout/blob/v1/README.md) for previous
     # Whether to download Git-LFS files
     # Default: false
     lfs: ''
-
-    # Whether to checkout submodules: `true` to checkout submodules or `recursive` to
-    # recursively checkout submodules.
-    #
-    # When the `ssh-key` input is not provided, SSH URLs beginning with
-    # `git@github.com:` are converted to HTTPS.
-    #
-    # Default: false
-    submodules: ''
 ```
 <!-- end usage -->
 


### PR DESCRIPTION
Submodules are no longer supported in checkout v2

Keep up the nice work with GH actions ;-)