### PR TITLE
Remove mention to beta for v2 in CHANGELOG and add link in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2 (beta)
+## v2
 
 - Improved fetch performance
   - The default behavior now fetches only the SHA being checked-out

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
   - When Git 2.18 or higher is not in the PATH, the REST API will be used to download the files
   - When using a job container, the container's PATH is used
 
-Refer [here](https://github.com/actions/checkout/blob/v1/README.md) for previous versions.
+Refer to [CHANGELOG](./CHANGELOG.md) to see differences with previous versions
+or consult the [v1 README](https://github.com/actions/checkout/blob/v1/README.md).
 
 # Usage
 


### PR DESCRIPTION
Two very minor edits, but I found useful enough to make a PR.

This would help when searching for what were the difference between checkout v1 and v2.
