### PR TITLE
fix prettier glob pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "lib/main.js",
   "scripts": {
     "build": "tsc && ncc build && node lib/misc/generate-docs.js",
-    "format": "prettier --write **/*.ts",
-    "format-check": "prettier --check **/*.ts",
+    "format": "prettier --write '**/*.ts'",
+    "format-check": "prettier --check '**/*.ts'",
     "lint": "eslint src/**/*.ts",
     "test": "jest"
   },


### PR DESCRIPTION
Noticed that if you don't quote the glob pattern it doesn't reach past the first level.

After this change `src/misc/generate-docs.ts` will be included:
```diff
npm run format

>> checkout@2.0.2 format /Users/peter.evans/git/checkout
>> prettier --write '**/*.ts'

__test__/git-auth-helper.test.ts 303ms
__test__/git-directory-helper.test.ts 84ms
__test__/git-version.test.ts 23ms
__test__/input-helper.test.ts 22ms
__test__/ref-helper.test.ts 28ms
__test__/retry-helper.test.ts 12ms
src/fs-helper.ts 9ms
src/git-auth-helper.ts 64ms
src/git-command-manager.ts 79ms
src/git-directory-helper.ts 19ms
src/git-source-provider.ts 30ms
src/git-source-settings.ts 10ms
src/git-version.ts 17ms
src/github-api-helper.ts 22ms
src/input-helper.ts 27ms
src/main.ts 11ms
+src/misc/generate-docs.ts 23ms
src/ref-helper.ts 18ms
src/regexp-helper.ts 6ms
src/retry-helper.ts 9ms
src/state-helper.ts 7ms
src/url-helper.ts 5ms
```