### PR TITLE
Update README regarding `pull_request_target`

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Refer [here](https://github.com/actions/checkout/blob/v1/README.md) for previous
 - [Checkout pull request HEAD commit instead of merge commit](#Checkout-pull-request-HEAD-commit-instead-of-merge-commit)
 - [Checkout pull request on closed event](#Checkout-pull-request-on-closed-event)
 - [Push a commit using the built-in token](#Push-a-commit-using-the-built-in-token)
+- [Checkout pull request on `pull_request_target`](#Checkout-pull-request-on-pull_request_target)
 
 ## Fetch all history for all tags and branches
 
@@ -213,6 +214,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 ```
+
+## Checkout pull request on `pull_request_target`
+
+```yaml
+on:
+  - pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+```
+
+**WARNING! NEVER** run code from pull requests of public repositories! The token of `pull_request_target` event has write access.
 
 ## Push a commit using the built-in token
 


### PR DESCRIPTION
GitHub [has introduced](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) a new event type: `pull_request_target`, which allows to run workflows from base branch and pass a token with write permission.

> In order to solve this, we’ve added a new `pull_request_target` event, which behaves in an almost identical way to the `pull_request` event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request. This event can be used in combination with the private repository settings as well.

It could be potentially dangerous to checkout and run code from public forks, but people will still try it. I think the best place for the warning is the checkout action, itself.