### PR TITLE
Add missing `await`s

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,7 @@
     "@typescript-eslint/no-empty-interface": "error",
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-extraneous-class": "error",
+    "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/no-for-in-array": "error",
     "@typescript-eslint/no-inferrable-types": "error",
     "@typescript-eslint/no-misused-new": "error",

--- a/dist/index.js
+++ b/dist/index.js
@@ -5498,7 +5498,7 @@ class GitAuthHelper {
                 const configPaths = output.match(/(?<=(^|\n)file:)[^\t]+(?=\tremote\.origin\.url)/g) || [];
                 for (const configPath of configPaths) {
                     core.debug(`Replacing token placeholder in '${configPath}'`);
-                    this.replaceTokenPlaceholder(configPath);
+                    yield this.replaceTokenPlaceholder(configPath);
                 }
                 if (this.settings.sshKey) {
                     // Configure core.sshCommand
@@ -9594,7 +9594,7 @@ function downloadRepository(authToken, owner, repo, ref, commit, repositoryPath)
         else {
             yield toolCache.extractTar(archivePath, extractPath);
         }
-        io.rmRF(archivePath);
+        yield io.rmRF(archivePath);
         // Determine the path of the repository content. The archive contains
         // a top-level folder and the repository content is inside.
         const archiveFileNames = yield fs.promises.readdir(extractPath);
@@ -9613,7 +9613,7 @@ function downloadRepository(authToken, owner, repo, ref, commit, repositoryPath)
                 yield io.mv(sourcePath, targetPath);
             }
         }
-        io.rmRF(extractPath);
+        yield io.rmRF(extractPath);
     });
 }
 exports.downloadRepository = downloadRepository;

--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -148,7 +148,7 @@ class GitAuthHelper {
         output.match(/(?<=(^|\n)file:)[^\t]+(?=\tremote\.origin\.url)/g) || []
       for (const configPath of configPaths) {
         core.debug(`Replacing token placeholder in '${configPath}'`)
-        this.replaceTokenPlaceholder(configPath)
+        await this.replaceTokenPlaceholder(configPath)
       }
 
       if (this.settings.sshKey) {

--- a/src/github-api-helper.ts
+++ b/src/github-api-helper.ts
@@ -47,7 +47,7 @@ export async function downloadRepository(
   } else {
     await toolCache.extractTar(archivePath, extractPath)
   }
-  io.rmRF(archivePath)
+  await io.rmRF(archivePath)
 
   // Determine the path of the repository content. The archive contains
   // a top-level folder and the repository content is inside.
@@ -70,7 +70,7 @@ export async function downloadRepository(
       await io.mv(sourcePath, targetPath)
     }
   }
-  io.rmRF(extractPath)
+  await io.rmRF(extractPath)
 }
 
 /**


### PR DESCRIPTION
In our testing, this fixes a flakiness we observed in the recursive checkout of submodules, where `remote.origin.url` is _sometimes_ not set after checkout.

/cc @igfoo