### PR TITLE
Added separate parameter for submodules fetch depth

### DIFF
--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -763,6 +763,7 @@ async function setup(testName: string): Promise<void> {
     lfs: false,
     submodules: false,
     nestedSubmodules: false,
+    submodulesFetchDepth: 1,
     persistCredentials: true,
     ref: 'refs/heads/main',
     repositoryName: 'my-repo',

--- a/__test__/input-helper.test.ts
+++ b/__test__/input-helper.test.ts
@@ -75,6 +75,7 @@ describe('input-helper tests', () => {
     expect(settings.commit).toBeTruthy()
     expect(settings.commit).toBe('1234567890123456789012345678901234567890')
     expect(settings.fetchDepth).toBe(1)
+    expect(settings.submodulesFetchDepth).toBe(1)
     expect(settings.lfs).toBe(false)
     expect(settings.ref).toBe('refs/heads/some-ref')
     expect(settings.repositoryName).toBe('some-repo')
@@ -122,5 +123,19 @@ describe('input-helper tests', () => {
     const settings: IGitSourceSettings = inputHelper.getInputs()
     expect(settings.ref).toBe('refs/heads/some-other-ref')
     expect(settings.commit).toBeFalsy()
+  })
+
+  it('sets submodulesFetchDepth independently from fetchDepth', () => {
+    inputs['fetch-depth'] = '10'
+    inputs['submodules-fetch-depth'] = '20'
+
+    const settings: IGitSourceSettings = inputHelper.getInputs()
+    expect(settings.submodulesFetchDepth).toBe(20)
+  })
+
+  it('sets submodulesFetchDepth equal to fetchDepth by default', () => {
+    inputs['fetch-depth'] = '10'
+    const settings: IGitSourceSettings = inputHelper.getInputs()
+    expect(settings.submodulesFetchDepth).toBe(10)
   })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -6255,7 +6255,7 @@ function getSource(settings) {
                     // Checkout submodules
                     core.startGroup('Fetching submodules');
                     yield git.submoduleSync(settings.nestedSubmodules);
-                    yield git.submoduleUpdate(settings.fetchDepth, settings.nestedSubmodules);
+                    yield git.submoduleUpdate(settings.submodulesFetchDepth, settings.nestedSubmodules);
                     yield git.submoduleForeach('git config --local gc.auto 0', settings.nestedSubmodules);
                     core.endGroup();
                     // Persist credentials
@@ -14572,6 +14572,12 @@ function getInputs() {
         result.fetchDepth = 0;
     }
     core.debug(`fetch depth = ${result.fetchDepth}`);
+    // Submodules fetch depth
+    result.submodulesFetchDepth = Math.floor(Number(core.getInput('submodules-fetch-depth') || '-1'));
+    if (isNaN(result.submodulesFetchDepth) || result.submodulesFetchDepth < 0) {
+        result.submodulesFetchDepth = result.fetchDepth;
+    }
+    core.debug(`submodules fetch depth = ${result.submodulesFetchDepth}`);
     // LFS
     result.lfs = (core.getInput('lfs') || 'false').toUpperCase() === 'TRUE';
     core.debug(`lfs = ${result.lfs}`);

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -180,7 +180,7 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
         core.startGroup('Fetching submodules')
         await git.submoduleSync(settings.nestedSubmodules)
         await git.submoduleUpdate(
-          settings.fetchDepth,
+          settings.submodulesFetchDepth,
           settings.nestedSubmodules
         )
         await git.submoduleForeach(

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -50,6 +50,11 @@ export interface IGitSourceSettings {
   nestedSubmodules: boolean
 
   /**
+   * The fetch depth for submodules
+   */
+  submodulesFetchDepth: number
+
+  /**
    * The auth token to use when fetching the repository
    */
   authToken: string

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -88,6 +88,15 @@ export function getInputs(): IGitSourceSettings {
   }
   core.debug(`fetch depth = ${result.fetchDepth}`)
 
+  // Submodules fetch depth
+  result.submodulesFetchDepth = Math.floor(
+    Number(core.getInput('submodules-fetch-depth') || '-1')
+  )
+  if (isNaN(result.submodulesFetchDepth) || result.submodulesFetchDepth < 0) {
+    result.submodulesFetchDepth = result.fetchDepth
+  }
+  core.debug(`submodules fetch depth = ${result.submodulesFetchDepth}`)
+
   // LFS
   result.lfs = (core.getInput('lfs') || 'false').toUpperCase() === 'TRUE'
   core.debug(`lfs = ${result.lfs}`)


### PR DESCRIPTION
Using the same value of the fetch depth in the main repository and submodules can lead to a problem that cloned submodule will not contain commit referenced in the main repository. If the depth is not enough and there are commits in the submodule repository on top of the referenced one, the submodule update can fail with the following output:
```
/usr/bin/git submodule sync
/usr/bin/git -c protocol.version=2 submodule update --init --force --depth=1
Submodule '<some-submodule>' (https://<submodule>.git) registered for path '<submodule-path>'
Cloning into '/home/runner/work/<sobmodule-path>'...
Error: error: Server does not allow request for unadvertised object <some-sha>
Fetched in submodule path '<sobmodule-path>', but it did not contain <some-sha>. Direct fetching of that commit failed.
Error: The process '/usr/bin/git' failed with exit code 1
```
At the same time increasing general fetch depth will increase fetch timing for the main repository.
The proposal is to separate the parameters by introduction of the 'submodules-fetch-depth' parameter that will default to 
fetch-depth value if not present.

