### PR TITLE
Improve docs for checking out a private repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Refer [here](https://github.com/actions/checkout/blob/v1/README.md) for previous
   uses: actions/checkout@v2
   with:
     repository: my-org/my-private-tools
-    token: ${{ secrets.GitHub_PAT }} # `GitHub_PAT` is a secret that contains your PAT
+    token: ${{ secrets.MY_GITHUB_PAT }} # `MY_GITHUB_PAT` is a secret you create that contains your PAT
     path: my-tools
 ```
 


### PR DESCRIPTION
I tried using `actions/checkout` to checkout a private repo using the README, and I bumped into two issues:

1. I thought that `secrets.GitHub_PAT` was something that I got for free. It turns out that the user must create this secret themselves.
2. User-created secrets [cannot start with `GitHub_`](https://docs.github.com/en/actions/reference/encrypted-secrets).

This change updates the README to clarify both of those points.