### PR TITLE
Create check-dist.yml

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -4,7 +4,7 @@
 # For our project, we generate this file through a build process
 # from other source files.
 # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
-name: Check dist/
+name: Check dist
 
 on:
   push:

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -32,15 +32,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Move the committed index.js file
-        run: mv dist/index.js /tmp
-
       - name: Rebuild the index.js file
         run: npm run build
 
-      - name: Compare the expected and actual index.js files
-        run: git diff --ignore-all-space dist/index.js /tmp/index.js
-        id: diff
+      - name: Compare the expected and actual dist/ directories
+        run: |
+          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+            echo "Detected uncommitted changes after build.  See status below:"
+            git diff
+            exit 1
+          fi
 
       # If index.js was different than expected, upload the expected version as an artifact
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -43,9 +43,9 @@ jobs:
             exit 1
           fi
 
-      # If index.js was different than expected, upload the expected version as an artifact
+      # If dist/ was different than expected, upload the expected version as an artifact
       - uses: actions/upload-artifact@v2
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
-          name: index.js
-          path: dist/index.js
+          name: dist
+          path: dist/

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -1,0 +1,50 @@
+# `dist/index.js` is a special file in Actions.
+# When you reference an action with `uses:` in a workflow,
+# `index.js` is the code that will run.
+# For our project, we generate this file through a build process
+# from other source files.
+# We need to make sure the checked-in `index.js` actually matches what we expect it to be.
+name: Check dist/
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+
+jobs:
+  check-dist:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Move the committed index.js file
+        run: mv dist/index.js /tmp
+
+      - name: Rebuild the index.js file
+        run: npm run build
+
+      - name: Compare the expected and actual index.js files
+        run: git diff --ignore-all-space dist/index.js /tmp/index.js
+        id: diff
+
+      # If index.js was different than expected, upload the expected version as an artifact
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() && steps.diff.conclusion == 'failure' }}
+        with:
+          name: index.js
+          path: dist/index.js


### PR DESCRIPTION
This adds a workflow to check the contents of the checked-in `dist/index.js` against the expected version.

See https://github.com/actions/upload-artifact/pull/227 for background and rationale.