### PR TITLE
Set default user.name and user.email

### DIFF
--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core'
+import * as github from '@actions/github'
 import * as fsHelper from './fs-helper'
 import * as gitAuthHelper from './git-auth-helper'
 import * as gitCommandManager from './git-command-manager'
@@ -216,6 +217,14 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
       settings.ref,
       settings.commit
     )
+
+    // Set default author
+    if (!await git.configExists('user.name', true) {
+      await git.config('user.name', github.context.workflow, true)
+    }
+    if (!await git.configExists('user.email', true) {
+      await git.config('user.email', 'github-actions@github.com', true)
+    }
   } finally {
     // Remove auth
     if (!settings.persistCredentials) {


### PR DESCRIPTION
This PR sets up a default `user.name` and `user.email` for scripting `git commit`. Users can continue to configure their own values as now, this PR just affords the option not to.

Shouldn't affect existing users: If users `git config --global user.{name,email}` before `actions/checkout`, this will respect existing values. If they `git config --global` after `actions/checkout` they'll overwrite these defaults. If they `git config --local` (before or after), those values take precedence.

Fixes #13, although the issue proposed defaulting to the author/user from the event that triggered the action.

Also discussed in #158, although the PR doesn't propose defaults.

Configuring `user.{name,email}`/scripting `git commit` is documented in the [README.md](https://github.com/actions/checkout#push-a-commit-using-the-built-in-token). The relevant text of [ADR 0153](https://github.com/actions/checkout/blob/main/adrs/0153-checkout-v2.md#persist-credentials) reads:
> Note:
> - Users scripting `git commit` may need to set the username and email. The service does not provide any reasonable default value. Users can add `git config user.name <NAME>` and `git config user.email <EMAIL>`. We will document this guidance.

### Default user.name

I used [`$GITHUB_WORKFLOW`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#:~:text=the%20name%20of%20the%20workflow.%20if%20the%20workflow%20file%20doesn't%20specify%20a%20name%2C%20the%20value%20of%20this%20property%20is%20the%20full%20path%20of%20the%20workflow%20file%20in%20the%20repository.) for the default `user.name` because it's the most helpful value to have in there? Other proposals include the current [README.md](https://github.com/actions/checkout#push-a-commit-using-the-built-in-token) value ("github-actions") and the [author/user from the event that triggered the action](https://github.com/actions/checkout/pull/158#discussion_r379766291).

Here's how `$GITHUB_WORKFLOW` looks in GitHub's UI -- however I'm equally happy if a different default is implemented: ![Screenshot from 2021-09-10 10-55-25](https://user-images.githubusercontent.com/78493/133482754-1ce6c001-509e-437c-8d4b-ca1ca7ce97c3.png)

### Default user.email

I went with the current [README.md](https://github.com/actions/checkout#push-a-commit-using-the-built-in-token) value ("github-actions@github.com"), however @JojOatXGME [lays out the options](https://github.com/actions/checkout/issues/13#issuecomment-724415212).