### PR TITLE
Add `shallow-since` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ Refer [here](https://github.com/actions/checkout/blob/v1/README.md) for previous
     clean: ''
 
     # Number of commits to fetch. 0 indicates all history for all branches and tags.
-    # Default: 1
     fetch-depth: ''
+
+    # Date like `2days` or `1970-01-01`. Fetch a history after the specified time.
+    shallow-since: ''
 
     # Whether to download Git-LFS files
     # Default: false

--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -760,6 +760,7 @@ async function setup(testName: string): Promise<void> {
     clean: true,
     commit: '',
     fetchDepth: 1,
+    shallowSince: '',
     lfs: false,
     submodules: false,
     nestedSubmodules: false,

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,8 @@ inputs:
     default: true
   fetch-depth:
     description: 'Number of commits to fetch. 0 indicates all history for all branches and tags.'
-    default: 1
+  shallow-since:
+    description: 'Date like `2days` or `1970-01-01`. Fetch a history after the specified time.'
   lfs:
     description: 'Whether to download Git-LFS files'
     default: false

--- a/adrs/0153-checkout-v2.md
+++ b/adrs/0153-checkout-v2.md
@@ -72,6 +72,8 @@ We want to take this opportunity to make behavioral changes, from v1. This docum
   fetch-depth:
     description: 'Number of commits to fetch. 0 indicates all history for all tags and branches.'
     default: 1
+  shallow-since:
+    description: 'Date like `2days` or `1970-01-01`. Fetch a history after the specified time.'
   lfs:
     description: 'Whether to download Git-LFS files'
     default: false
@@ -155,7 +157,7 @@ Fetch only the SHA being built and set depth=1. This significantly reduces the f
 
 If a SHA isn't available (e.g. multi repo), then fetch only the specified ref with depth=1.
 
-The input `fetch-depth` can be used to control the depth.
+The input `fetch-depth` and `shallow-since` can be used to control the depth.
 
 Note:
 - Fetching a single commit is supported by Git wire protocol version 2. The git client uses protocol version 0 by default. The desired protocol version can be overridden in the git config or on the fetch command line invocation (`-c protocol.version=2`). We will override on the fetch command line, for transparency.

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -24,7 +24,11 @@ export interface IGitCommandManager {
     globalConfig?: boolean
   ): Promise<void>
   configExists(configKey: string, globalConfig?: boolean): Promise<boolean>
-  fetch(refSpec: string[], fetchDepth?: number): Promise<void>
+  fetch(
+    refSpec: string[],
+    fetchDepth?: number,
+    shallowSince?: string
+  ): Promise<void>
   getDefaultBranch(repositoryUrl: string): Promise<string>
   getWorkingDirectory(): string
   init(): Promise<void>
@@ -39,7 +43,11 @@ export interface IGitCommandManager {
   shaExists(sha: string): Promise<boolean>
   submoduleForeach(command: string, recursive: boolean): Promise<string>
   submoduleSync(recursive: boolean): Promise<void>
-  submoduleUpdate(fetchDepth: number, recursive: boolean): Promise<void>
+  submoduleUpdate(
+    fetchDepth: number,
+    recursive: boolean,
+    shallowSince?: string
+  ): Promise<void>
   tagExists(pattern: string): Promise<boolean>
   tryClean(): Promise<boolean>
   tryConfigUnset(configKey: string, globalConfig?: boolean): Promise<boolean>
@@ -168,7 +176,11 @@ class GitCommandManager {
     return output.exitCode === 0
   }
 
-  async fetch(refSpec: string[], fetchDepth?: number): Promise<void> {
+  async fetch(
+    refSpec: string[],
+    fetchDepth?: number,
+    shallowSince?: string
+  ): Promise<void> {
     const args = ['-c', 'protocol.version=2', 'fetch']
     if (!refSpec.some(x => x === refHelper.tagsRefSpec)) {
       args.push('--no-tags')
@@ -177,6 +189,8 @@ class GitCommandManager {
     args.push('--prune', '--progress', '--no-recurse-submodules')
     if (fetchDepth && fetchDepth > 0) {
       args.push(`--depth=${fetchDepth}`)
+    } else if (shallowSince) {
+      args.push(`--shallow-since=${shallowSince}`)
     } else if (
       fshelper.fileExistsSync(
         path.join(this.workingDirectory, '.git', 'shallow')
@@ -310,11 +324,18 @@ class GitCommandManager {
     await this.execGit(args)
   }
 
-  async submoduleUpdate(fetchDepth: number, recursive: boolean): Promise<void> {
+  async submoduleUpdate(
+    fetchDepth: number,
+    recursive: boolean,
+    shallowSince?: string
+  ): Promise<void> {
     const args = ['-c', 'protocol.version=2']
     args.push('submodule', 'update', '--init', '--force')
     if (fetchDepth > 0) {
       args.push(`--depth=${fetchDepth}`)
+    }
+    if (shallowSince) {
+      args.push(`--shallow-since=${shallowSince}`)
     }
 
     if (recursive) {

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -187,10 +187,10 @@ class GitCommandManager {
     }
 
     args.push('--prune', '--progress', '--no-recurse-submodules')
-    if (fetchDepth && fetchDepth > 0) {
-      args.push(`--depth=${fetchDepth}`)
-    } else if (shallowSince) {
+    if (shallowSince) {
       args.push(`--shallow-since=${shallowSince}`)
+    } else if (fetchDepth && fetchDepth > 0) {
+      args.push(`--depth=${fetchDepth}`)
     } else if (
       fshelper.fileExistsSync(
         path.join(this.workingDirectory, '.git', 'shallow')

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -141,7 +141,7 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
       }
     } else {
       const refSpec = refHelper.getRefSpec(settings.ref, settings.commit)
-      await git.fetch(refSpec, settings.fetchDepth)
+      await git.fetch(refSpec, settings.fetchDepth, settings.shallowSince)
     }
     core.endGroup()
 
@@ -181,7 +181,8 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
         await git.submoduleSync(settings.nestedSubmodules)
         await git.submoduleUpdate(
           settings.fetchDepth,
-          settings.nestedSubmodules
+          settings.nestedSubmodules,
+          settings.shallowSince
         )
         await git.submoduleForeach(
           'git config --local gc.auto 0',

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -35,6 +35,11 @@ export interface IGitSourceSettings {
   fetchDepth: number
 
   /**
+   * The date which a history after is fetched
+   */
+  shallowSince: string
+
+  /**
    * Indicates whether to fetch LFS objects
    */
   lfs: boolean

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -81,6 +81,12 @@ export function getInputs(): IGitSourceSettings {
   result.clean = (core.getInput('clean') || 'true').toUpperCase() === 'TRUE'
   core.debug(`clean = ${result.clean}`)
 
+  if (core.getInput('fetch-depth') && core.getInput('shallow-since')) {
+    throw new Error(
+      '`fetch-depth` and `shallow-since` cannot be used at the same time'
+    )
+  }
+
   // Fetch depth
   result.fetchDepth = Math.floor(Number(core.getInput('fetch-depth') || '1'))
   if (isNaN(result.fetchDepth) || result.fetchDepth < 0) {
@@ -91,12 +97,6 @@ export function getInputs(): IGitSourceSettings {
   // Shallow since
   result.shallowSince = core.getInput('shallow-since')
   core.debug(`shallow since = ${result.shallowSince}`)
-
-  if (result.fetchDepth > 0 && result.shallowSince) {
-    throw new Error(
-      '`fetch-depath` and `shallow-since` cannot be used at the same time'
-    )
-  }
 
   // LFS
   result.lfs = (core.getInput('lfs') || 'false').toUpperCase() === 'TRUE'

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -88,6 +88,16 @@ export function getInputs(): IGitSourceSettings {
   }
   core.debug(`fetch depth = ${result.fetchDepth}`)
 
+  // Shallow since
+  result.shallowSince = core.getInput('shallow-since')
+  core.debug(`shallow since = ${result.shallowSince}`)
+
+  if (result.fetchDepth > 0 && result.shallowSince) {
+    throw new Error(
+      '`fetch-depath` and `shallow-since` cannot be used at the same time'
+    )
+  }
+
   // LFS
   result.lfs = (core.getInput('lfs') || 'false').toUpperCase() === 'TRUE'
   core.debug(`lfs = ${result.lfs}`)


### PR DESCRIPTION
In some case, we would like to specify the date rather than the depth to fetch.
In my case, I want to check changed files for the last n days on CI.
It would be useful to add `shallow-since` setting similar to `fetch-depth`.