### PR TITLE
Add specific permissions to check-dist.yml workflow

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -17,8 +17,12 @@ on:
       - '**.md'
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   check-dist:
+    permissions:
+      contents: read # for actions/checkout to fetch code
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR adds token `permissions` to the check-dist.yml workflow. This is a security best practice as per [GitHub](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/) and is checked by [OSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions). 

1. I am collating security information about different GitHub Actions in an [open-source knowledge-base](https://github.com/step-security/secure-workflows/tree/main/knowledge-base) to calculate minimum `GITHUB_TOKEN` permissions and restrict outbound traffic to allowed domains. As an owner of `actions/checkout` Action, please review info about it in the knowledge-base [here](https://github.com/step-security/secure-workflows/blob/main/knowledge-base/actions/checkout/action-security.yml) - specifically the reason for the token permissions the Action needs and expected outbound calls it makes. e.g. the ` # for actions/checkout to fetch code` part in the check-dist.yml file comes from the knowledge base. 
2. JFYI - You can easily add token permissions and other security best practices to other workflows in this repo using https://app.stepsecurity.io. It uses the knowledge base mentioned above...Do let me know if you have feedback. Thanks!