### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -110,9 +110,9 @@ class GitCommandManager {
       branch = branch.trim()
       if (branch) {
         if (branch.startsWith('refs/heads/')) {
-          branch = branch.substr('refs/heads/'.length)
+          branch = branch.slice('refs/heads/'.length)
         } else if (branch.startsWith('refs/remotes/')) {
-          branch = branch.substr('refs/remotes/'.length)
+          branch = branch.slice('refs/remotes/'.length)
         }
 
         result.push(branch)
@@ -217,7 +217,7 @@ class GitCommandManager {
         line = line.trim()
         if (line.startsWith('ref:') || line.endsWith('HEAD')) {
           return line
-            .substr('ref:'.length, line.length - 'ref:'.length - 'HEAD'.length)
+            .slice('ref:'.length, line.length - 'HEAD'.length)
             .trim()
         }
       }

--- a/src/git-directory-helper.ts
+++ b/src/git-directory-helper.ts
@@ -64,11 +64,11 @@ export async function prepareExistingDirectory(
       if (ref) {
         ref = ref.startsWith('refs/') ? ref : `refs/heads/${ref}`
         if (ref.startsWith('refs/heads/')) {
-          const upperName1 = ref.toUpperCase().substr('REFS/HEADS/'.length)
+          const upperName1 = ref.toUpperCase().slice('REFS/HEADS/'.length)
           const upperName1Slash = `${upperName1}/`
           branches = await git.branchList(true)
           for (const branch of branches) {
-            const upperName2 = branch.substr('origin/'.length).toUpperCase()
+            const upperName2 = branch.slice('origin/'.length).toUpperCase()
             const upperName2Slash = `${upperName2}/`
             if (
               upperName1.startsWith(upperName2Slash) ||

--- a/src/misc/generate-docs.ts
+++ b/src/misc/generate-docs.ts
@@ -43,7 +43,7 @@ function updateUsage(
   const newReadme: string[] = []
 
   // Append the beginning
-  newReadme.push(originalReadme.substr(0, startTokenIndex + startToken.length))
+  newReadme.push(originalReadme.slice(0, startTokenIndex + startToken.length))
 
   // Build the new usage section
   newReadme.push('```yaml', `- uses: ${actionReference}`, '  with:')
@@ -68,9 +68,9 @@ function updateUsage(
       // Longer than width? Find a space to break apart
       let segment: string = description
       if (description.length > width) {
-        segment = description.substr(0, width + 1)
+        segment = description.slice(0, width + 1)
         while (!segment.endsWith(' ') && !segment.endsWith('\n') && segment) {
-          segment = segment.substr(0, segment.length - 1)
+          segment = segment.slice(0, -1)
         }
 
         // Trimmed too much?
@@ -84,14 +84,14 @@ function updateUsage(
       // Check for newline
       const newlineIndex = segment.indexOf('\n')
       if (newlineIndex >= 0) {
-        segment = segment.substr(0, newlineIndex + 1)
+        segment = segment.slice(0, newlineIndex + 1)
       }
 
       // Append segment
       newReadme.push(`    # ${segment}`.trimRight())
 
       // Remaining
-      description = description.substr(segment.length)
+      description = description.slice(segment.length)
     }
 
     if (input.default !== undefined) {
@@ -113,7 +113,7 @@ function updateUsage(
   newReadme.push('```')
 
   // Append the end
-  newReadme.push(originalReadme.substr(endTokenIndex))
+  newReadme.push(originalReadme.slice(endTokenIndex))
 
   // Write the new README
   fs.writeFileSync(readmePath, newReadme.join(os.EOL))

--- a/src/ref-helper.ts
+++ b/src/ref-helper.ts
@@ -273,8 +273,8 @@ function select(obj: any, path: string): any {
     return obj[path]
   }
 
-  const key = path.substr(0, i)
-  return select(obj[key], path.substr(i + 1))
+  const key = path.slice(0, i)
+  return select(obj[key], path.slice(i + 1))
 }
 
 function isGhes(): boolean {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.