### PR TITLE
Enforce safe directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.1
+- [Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`](https://github.com/actions/checkout/pull/762)
+- [Bumped various npm package versions](https://github.com/actions/checkout/pull/744)
+
 ## v3.0.0
 
 - [Update to node 16](https://github.com/actions/checkout/pull/689)

--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -643,10 +643,11 @@ describe('git-auth-helper tests', () => {
     expect(gitConfigContent.indexOf('http.')).toBeLessThan(0)
   })
 
-  const removeGlobalAuth_removesOverride = 'removeGlobalAuth removes override'
-  it(removeGlobalAuth_removesOverride, async () => {
+  const removeGlobalConfig_removesOverride =
+    'removeGlobalConfig removes override'
+  it(removeGlobalConfig_removesOverride, async () => {
     // Arrange
-    await setup(removeGlobalAuth_removesOverride)
+    await setup(removeGlobalConfig_removesOverride)
     const authHelper = gitAuthHelper.createAuthHelper(git, settings)
     await authHelper.configureAuth()
     await authHelper.configureGlobalAuth()
@@ -655,7 +656,7 @@ describe('git-auth-helper tests', () => {
     await fs.promises.stat(path.join(git.env['HOME'], '.gitconfig'))
 
     // Act
-    await authHelper.removeGlobalAuth()
+    await authHelper.removeGlobalConfig()
 
     // Assert
     expect(git.env['HOME']).toBeUndefined()

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -36,68 +36,77 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
   const git = await getGitCommandManager(settings)
   core.endGroup()
 
-  // Prepare existing directory, otherwise recreate
-  if (isExisting) {
-    await gitDirectoryHelper.prepareExistingDirectory(
-      git,
-      settings.repositoryPath,
-      repositoryUrl,
-      settings.clean,
-      settings.ref
-    )
-  }
+  let authHelper: gitAuthHelper.IGitAuthHelper | null = null
+  try {
+    if (git) {
+      authHelper = gitAuthHelper.createAuthHelper(git, settings)
+      await authHelper.configureTempGlobalConfig()
+    }
 
-  if (!git) {
-    // Downloading using REST API
-    core.info(`The repository will be downloaded using the GitHub REST API`)
-    core.info(
-      `To create a local Git repository instead, add Git ${gitCommandManager.MinimumGitVersion} or higher to the PATH`
-    )
-    if (settings.submodules) {
-      throw new Error(
-        `Input 'submodules' not supported when falling back to download using the GitHub REST API. To create a local Git repository instead, add Git ${gitCommandManager.MinimumGitVersion} or higher to the PATH.`
-      )
-    } else if (settings.sshKey) {
-      throw new Error(
-        `Input 'ssh-key' not supported when falling back to download using the GitHub REST API. To create a local Git repository instead, add Git ${gitCommandManager.MinimumGitVersion} or higher to the PATH.`
+    // Prepare existing directory, otherwise recreate
+    if (isExisting) {
+      await gitDirectoryHelper.prepareExistingDirectory(
+        git,
+        settings.repositoryPath,
+        repositoryUrl,
+        settings.clean,
+        settings.ref
       )
     }
 
-    await githubApiHelper.downloadRepository(
-      settings.authToken,
-      settings.repositoryOwner,
-      settings.repositoryName,
-      settings.ref,
-      settings.commit,
-      settings.repositoryPath
-    )
-    return
-  }
+    if (!git) {
+      // Downloading using REST API
+      core.info(`The repository will be downloaded using the GitHub REST API`)
+      core.info(
+        `To create a local Git repository instead, add Git ${gitCommandManager.MinimumGitVersion} or higher to the PATH`
+      )
+      if (settings.submodules) {
+        throw new Error(
+          `Input 'submodules' not supported when falling back to download using the GitHub REST API. To create a local Git repository instead, add Git ${gitCommandManager.MinimumGitVersion} or higher to the PATH.`
+        )
+      } else if (settings.sshKey) {
+        throw new Error(
+          `Input 'ssh-key' not supported when falling back to download using the GitHub REST API. To create a local Git repository instead, add Git ${gitCommandManager.MinimumGitVersion} or higher to the PATH.`
+        )
+      }
 
-  // Save state for POST action
-  stateHelper.setRepositoryPath(settings.repositoryPath)
+      await githubApiHelper.downloadRepository(
+        settings.authToken,
+        settings.repositoryOwner,
+        settings.repositoryName,
+        settings.ref,
+        settings.commit,
+        settings.repositoryPath
+      )
+      return
+    }
 
-  // Initialize the repository
-  if (
-    !fsHelper.directoryExistsSync(path.join(settings.repositoryPath, '.git'))
-  ) {
-    core.startGroup('Initializing the repository')
-    await git.init()
-    await git.remoteAdd('origin', repositoryUrl)
+    // Save state for POST action
+    stateHelper.setRepositoryPath(settings.repositoryPath)
+
+    // Initialize the repository
+    if (
+      !fsHelper.directoryExistsSync(path.join(settings.repositoryPath, '.git'))
+    ) {
+      core.startGroup('Initializing the repository')
+      await git.init()
+      await git.remoteAdd('origin', repositoryUrl)
+      core.endGroup()
+    }
+
+    // Disable automatic garbage collection
+    core.startGroup('Disabling automatic garbage collection')
+    if (!(await git.tryDisableAutomaticGarbageCollection())) {
+      core.warning(
+        `Unable to turn off git automatic garbage collection. The git fetch operation may trigger garbage collection and cause a delay.`
+      )
+    }
     core.endGroup()
-  }
 
-  // Disable automatic garbage collection
-  core.startGroup('Disabling automatic garbage collection')
-  if (!(await git.tryDisableAutomaticGarbageCollection())) {
-    core.warning(
-      `Unable to turn off git automatic garbage collection. The git fetch operation may trigger garbage collection and cause a delay.`
-    )
-  }
-  core.endGroup()
-
-  const authHelper = gitAuthHelper.createAuthHelper(git, settings)
-  try {
+    // If we didn't initialize it above, do it now
+    if (!authHelper) {
+      authHelper = gitAuthHelper.createAuthHelper(git, settings)
+    }
     // Configure auth
     core.startGroup('Setting up auth')
     await authHelper.configureAuth()
@@ -170,34 +179,26 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
 
     // Submodules
     if (settings.submodules) {
-      try {
-        // Temporarily override global config
-        core.startGroup('Setting up auth for fetching submodules')
-        await authHelper.configureGlobalAuth()
-        core.endGroup()
+      // Temporarily override global config
+      core.startGroup('Setting up auth for fetching submodules')
+      await authHelper.configureGlobalAuth()
+      core.endGroup()
 
-        // Checkout submodules
-        core.startGroup('Fetching submodules')
-        await git.submoduleSync(settings.nestedSubmodules)
-        await git.submoduleUpdate(
-          settings.fetchDepth,
-          settings.nestedSubmodules
-        )
-        await git.submoduleForeach(
-          'git config --local gc.auto 0',
-          settings.nestedSubmodules
-        )
-        core.endGroup()
+      // Checkout submodules
+      core.startGroup('Fetching submodules')
+      await git.submoduleSync(settings.nestedSubmodules)
+      await git.submoduleUpdate(settings.fetchDepth, settings.nestedSubmodules)
+      await git.submoduleForeach(
+        'git config --local gc.auto 0',
+        settings.nestedSubmodules
+      )
+      core.endGroup()
 
-        // Persist credentials
-        if (settings.persistCredentials) {
-          core.startGroup('Persisting credentials for submodules')
-          await authHelper.configureSubmoduleAuth()
-          core.endGroup()
-        }
-      } finally {
-        // Remove temporary global config override
-        await authHelper.removeGlobalAuth()
+      // Persist credentials
+      if (settings.persistCredentials) {
+        core.startGroup('Persisting credentials for submodules')
+        await authHelper.configureSubmoduleAuth()
+        core.endGroup()
       }
     }
 
@@ -218,10 +219,13 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
     )
   } finally {
     // Remove auth
-    if (!settings.persistCredentials) {
-      core.startGroup('Removing auth')
-      await authHelper.removeAuth()
-      core.endGroup()
+    if (authHelper) {
+      if (!settings.persistCredentials) {
+        core.startGroup('Removing auth')
+        await authHelper.removeAuth()
+        core.endGroup()
+      }
+      authHelper.removeGlobalConfig()
     }
   }
 }
@@ -244,7 +248,12 @@ export async function cleanup(repositoryPath: string): Promise<void> {
 
   // Remove auth
   const authHelper = gitAuthHelper.createAuthHelper(git)
-  await authHelper.removeAuth()
+  try {
+    await authHelper.configureTempGlobalConfig(repositoryPath)
+    await authHelper.removeAuth()
+  } finally {
+    await authHelper.removeGlobalConfig()
+  }
 }
 
 async function getGitCommandManager(


### PR DESCRIPTION
This pr fixes #760 by setting the repositories path as a safe directory when running checkout and removing that config on cleanup.

We aren't able to set it as a local config, as this setting only works for global configs.

So, using the standard we used for submodules, lets go ahead and copy the existing global config to a new location. Then we can go ahead and modify that global config (so we don't modify like a users global config if they test something on a self hosted runner real fast). Then, we can delete that global config at the end of the checkout step.

This does carry some limitations, it doesn't persist this configuration for the duration of the job mainly. So if your job pushes to git or something after checkout, that will continue to fail. We need to figure out how to address this at an ecosystem level, outside of the checkout action.