### PR TITLE
Add Config Options to Override github Host

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,13 @@ inputs:
   set-safe-directory:
     description: Add repository path as safe.directory for Git global config by running `git config --global --add safe.directory <path>`
     default: true
+  
+    setHost:
+      description: >
+        override the github host that is set automatically to the github instance the action was called from. 
+        This is useful if you need to clone from an instance that is not the one your action is running from.  
+        For example, you need to clone a cloud hosted repo from an action run by an on prem instance.
+      required: false
 runs:
   using: node16
   main: dist/index.js

--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -52,7 +52,7 @@ class GitAuthHelper {
     this.settings = gitSourceSettings || (({} as unknown) as IGitSourceSettings)
 
     // Token auth header
-    const serverUrl = urlHelper.getServerUrl()
+    const serverUrl = urlHelper.getServerUrl(gitSourceSettings?.setHost)
     this.tokenConfigKey = `http.${serverUrl.origin}/.extraheader` // "origin" is SCHEME://HOSTNAME[:PORT]
     const basicCredential = Buffer.from(
       `x-access-token:${this.settings.authToken}`,

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -83,4 +83,10 @@ export interface IGitSourceSettings {
    * Indicates whether to add repositoryPath as safe.directory in git global config
    */
   setSafeDirectory: boolean
+
+  /**
+   * Set a host to override the automatic detection. Useful when you need to clone
+   * from cloud when running an action on an on prem server
+   */
+  setHost: string | undefined
 }

--- a/src/url-helper.ts
+++ b/src/url-helper.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert'
 import {IGitSourceSettings} from './git-source-settings'
 import {URL} from 'url'
+import { settings } from 'cluster'
 
 export function getFetchUrl(settings: IGitSourceSettings): string {
   assert.ok(
@@ -8,7 +9,7 @@ export function getFetchUrl(settings: IGitSourceSettings): string {
     'settings.repositoryOwner must be defined'
   )
   assert.ok(settings.repositoryName, 'settings.repositoryName must be defined')
-  const serviceUrl = getServerUrl()
+  const serviceUrl = getServerUrl(settings.setHost)
   const encodedOwner = encodeURIComponent(settings.repositoryOwner)
   const encodedName = encodeURIComponent(settings.repositoryName)
   if (settings.sshKey) {
@@ -19,7 +20,10 @@ export function getFetchUrl(settings: IGitSourceSettings): string {
   return `${serviceUrl.origin}/${encodedOwner}/${encodedName}`
 }
 
-export function getServerUrl(): URL {
+export function getServerUrl(configHost: string|undefined = undefined): URL {
+  if (configHost) {
+    return new URL(configHost)
+  }
   // todo: remove GITHUB_URL after support for GHES Alpha is no longer needed
   return new URL(
     process.env['GITHUB_SERVER_URL'] ||


### PR DESCRIPTION
This is possible solution to #630 it certainly allows you to override between github instances, but would need some investigation to see if putting a non github host in would work properly.

All this does is simply add an optional input called `setHost` that will be returned instead of the github urls if defined. 