### PR TITLE
Fix: Don't remove auth if submodules are off

### DIFF
--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -363,10 +363,12 @@ class GitAuthHelper {
       }
     }
 
-    const pattern = regexpHelper.escape(configKey)
-    await this.git.submoduleForeach(
-      `git config --local --name-only --get-regexp '${pattern}' && git config --local --unset-all '${configKey}' || :`,
-      true
+    if (this.settings.submodules) {
+      const pattern = regexpHelper.escape(configKey)
+      await this.git.submoduleForeach(
+        `git config --local --name-only --get-regexp '${pattern}' && git config --local --unset-all '${configKey}' || :`,
+        true
+      )
     )
   }
 }


### PR DESCRIPTION
Fix the action tries to remove auth even the submodules are disabled.
Fixes #610.