### PR TITLE
fix: octokit to use the correct enterprise url

### DIFF
--- a/src/github-api-helper.ts
+++ b/src/github-api-helper.ts
@@ -8,6 +8,7 @@ import * as retryHelper from './retry-helper'
 import * as toolCache from '@actions/tool-cache'
 import {default as uuid} from 'uuid/v4'
 import {Octokit} from '@octokit/rest'
+import { getAPIUrl } from './url-helper'
 
 const IS_WINDOWS = process.platform === 'win32'
 
@@ -83,7 +84,9 @@ export async function getDefaultBranch(
 ): Promise<string> {
   return await retryHelper.execute(async () => {
     core.info('Retrieving the default branch name')
-    const octokit = new github.GitHub(authToken)
+    const octokit = new github.GitHub(authToken, {
+      baseUrl: getAPIUrl()
+    })
     let result: string
     try {
       // Get the default branch from the repo info

--- a/src/url-helper.ts
+++ b/src/url-helper.ts
@@ -19,11 +19,26 @@ export function getFetchUrl(settings: IGitSourceSettings): string {
   return `${serviceUrl.origin}/${encodedOwner}/${encodedName}`
 }
 
-export function getServerUrl(): URL {
+function getServerUrlFromEnv(): string | undefined {
   // todo: remove GITHUB_URL after support for GHES Alpha is no longer needed
+  return process.env['GITHUB_SERVER_URL'] ||
+    process.env['GITHUB_URL']
+}
+
+export function getServerUrl(): URL {
   return new URL(
-    process.env['GITHUB_SERVER_URL'] ||
-      process.env['GITHUB_URL'] ||
+    getServerUrlFromEnv() ||
       'https://github.com'
+  )
+}
+
+export function getAPIUrl(): URL {
+  const urlFromEnv = getServerUrlFromEnv()
+  if (urlFromEnv) {
+    return new URL(`${urlFromEnv}/api/v3`)
+  }
+  
+  return new URL(
+    'https://api.github.com'
   )
 }


### PR DESCRIPTION
fixes https://github.com/actions/checkout/issues/563

This is just a quick fix. We should define a new input to properly specify the custom server URL.

I found out that even when we override the `GITHUB_SERVER_URL` environment variable, the `getDefaultBranch` initializes a new Octokit client without the `baseUrl` value regarding `GITHUB_SERVER_URL`.
Thus, the checkout action fails when we try to checkout to a private Github Enterprise Server repository with a misguided error messages.

I don't know the precise reasons why we haven't allowing any action users to customize the server URL via input though.
So, any comments are welcome.