### PR TITLE
Log more comprehensive commit information after checkout

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7478,8 +7478,8 @@ function getSource(settings) {
             }
             // Get commit information
             const commitInfo = yield git.log1();
-            // Log commit sha
-            yield git.log1("--format='%H'");
+            // Log commit information
+            yield git.log1("--format=oneline");
             // Check for incorrect pull request merge commit
             yield refHelper.checkCommitInfo(settings.authToken, commitInfo, settings.repositoryOwner, settings.repositoryName, settings.ref, settings.commit);
         }

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -222,8 +222,8 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
     // Get commit information
     const commitInfo = await git.log1()
 
-    // Log commit sha
-    await git.log1("--format='%H'")
+    // Log commit information
+    await git.log1("--format=oneline")
 
     // Check for incorrect pull request merge commit
     await refHelper.checkCommitInfo(


### PR DESCRIPTION
After checkout, the action currently logs the SHA-1 of the top most
commit. There are cases when this information is not very telling,
though. Consider the case of some automation that applies one or more
commits on top of what the repository already contained. If something
like this happens, the SHA-1 may be meaningless to the user. Given that
this information is unlikely to be programmatically evaluated, we may as
well include a bit more than only the commit SHA-1, in the hopes that it
provides some more useful information to the user.
To that end, this change proposes logging not just the SHA-1, but also
the commit summary. At the very least that gives a user a straw what to
look for if the commit is indeed not available locally, in the best case
we end up with a message about a merge commit, that helps users glean
information about the base commit as well:
> e0dcaaee9063ab55ffe2e0c8dcffb4a9611208f9 Merge e3aafdc7d10cf5002e39c5d4fe867d1b27d0ff7b into b77ffb30cfc5f58e957571d8541c6a7e3da19221