### PR TITLE
Adds force-api-download option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
     # running from unless specified. Example URLs are https://github.com or
     # https://my-ghes-server.example.com
     github-server-url: ''
+
+    # Force usage of REST API for downloading ref, even if git is installed locally.
+    # Default: false
+    force-api-download: ''
 ```
 <!-- end usage -->
 

--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -811,7 +811,8 @@ async function setup(testName: string): Promise<void> {
     sshStrict: true,
     workflowOrganizationId: 123456,
     setSafeDirectory: true,
-    githubServerUrl: githubServerUrl
+    githubServerUrl: githubServerUrl,
+    forceApiDownload: false
   }
 }
 

--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,10 @@ inputs:
   github-server-url:
     description: The base URL for the GitHub instance that you are trying to clone from, will use environment defaults to fetch from the same instance that the workflow is running from unless specified. Example URLs are https://github.com or https://my-ghes-server.example.com
     required: false
+  force-api-download:
+    description: Force usage of REST API for downloading ref, even if git is installed locally.
+    required: false
+    default: false
 runs:
   using: node16
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -7429,7 +7429,7 @@ function getSource(settings) {
             if (isExisting) {
                 yield gitDirectoryHelper.prepareExistingDirectory(git, settings.repositoryPath, repositoryUrl, settings.clean, settings.ref);
             }
-            if (!git) {
+            if (!git || settings.forceApiDownload) {
                 // Downloading using REST API
                 core.info(`The repository will be downloaded using the GitHub REST API`);
                 core.info(`To create a local Git repository instead, add Git ${gitCommandManager.MinimumGitVersion} or higher to the PATH`);
@@ -17390,6 +17390,9 @@ function getInputs() {
         // Determine the GitHub URL that the repository is being hosted from
         result.githubServerUrl = core.getInput('github-server-url');
         core.debug(`GitHub Host URL = ${result.githubServerUrl}`);
+        // Toggle force-api-download
+        result.forceApiDownload =
+            (core.getInput('force-api-download') || 'false').toUpperCase() === 'TRUE';
         return result;
     });
 }

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -71,7 +71,7 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
       )
     }
 
-    if (!git) {
+    if (!git || settings.forceApiDownload) {
       // Downloading using REST API
       core.info(`The repository will be downloaded using the GitHub REST API`)
       core.info(

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -88,4 +88,9 @@ export interface IGitSourceSettings {
    * User override on the GitHub Server/Host URL that hosts the repository to be cloned
    */
   githubServerUrl: string | undefined
+
+  /**
+   * Force the use of API download instead of git commands
+   */
+  forceApiDownload: boolean
 }

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -130,5 +130,8 @@ export async function getInputs(): Promise<IGitSourceSettings> {
   result.githubServerUrl = core.getInput('github-server-url')
   core.debug(`GitHub Host URL = ${result.githubServerUrl}`)
 
+  // Toggle force-api-download
+  result.forceApiDownload =
+    (core.getInput('force-api-download') || 'false').toUpperCase() === 'TRUE'
   return result
 }


### PR DESCRIPTION
Signed-off-by: CollinM <collinmcneese@github.com>

Adds `force-api-download` option to allow for downloading refs using REST API instead of installed `git` exec in instances where it would be more performant to do so related to issue #795 