### PR TITLE
Add workflow to update a main version

### DIFF
--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -1,0 +1,30 @@
+name: Update Main Version
+run-name: Move ${{ github.event.inputs.main_version }} to ${{ github.event.inputs.target }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: The tag or reference to use
+        required: true
+      main_version:
+        type: choice
+        description: The main version to update
+        options: 
+          - v3
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Git config
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+    - name: Tag new target
+      run: git tag -f ${{ github.event.inputs.main_version }} ${{ github.event.inputs.target }}
+    - name: Push new tag
+      run: git push origin ${{ github.event.inputs.main_version }} --force

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -10,7 +10,7 @@ on:
       main_version:
         type: choice
         description: The main version to update
-        options: 
+        options:
           - v3
 
 jobs:


### PR DESCRIPTION
This adds a new workflow to help moving a main version tag (e.g. `v3) to a new reference 
<img width="395" alt="Screenshot 2022-10-04 at 11 32 46" src="https://user-images.githubusercontent.com/6207785/193798574-6719d0c2-7bfc-4efd-9964-61dc7e91bebb.png">

