### PR TITLE
Use server hostname for org-id-style SSH URLs

### DIFF
--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -67,7 +67,7 @@ class GitAuthHelper {
     this.insteadOfValues.push(`git@${serverUrl.hostname}:`)
     if (this.settings.workflowOrganizationId) {
       this.insteadOfValues.push(
-        `org-${this.settings.workflowOrganizationId}@github.com:`
+        `org-${this.settings.workflowOrganizationId}@${serverUrl.hostname}:`
       )
     }
   }


### PR DESCRIPTION
GitHub Enterprise Server can show a SSH URLs that includes organization ID, too: https://docs.github.com/en/enterprise-server@3.6/organizations/managing-git-access-to-your-organizations-repositories/about-ssh-certificate-authorities#about-ssh-urls-with-ssh-certificates

Follow-up: ec3a7ce113134d7a93b817d10a8272cb61118579

🔗 https://github.com/actions/checkout/pull/621