### PR TITLE
wrap the command for submoduleForeach in quotes

### DIFF
--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -297,7 +297,10 @@ class GitCommandManager {
     if (recursive) {
       args.push('--recursive')
     }
+    # this is an ugly way to add the quotes around the command
+    args.push('"')
     args.push(command)
+    args.push('"')
 
     const output = await this.execGit(args)
     return output.stdout


### PR DESCRIPTION
This is a poor attempt at fixing the function to work as expected when `command` is a pipeline of some sort.

This may be a fix for #354 and others.