### PR TITLE
Suppress "detached head" advice during checkout

### DIFF
--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -123,7 +123,7 @@ class GitCommandManager {
   }
 
   async checkout(ref: string, startPoint: string): Promise<void> {
-    const args = ['checkout', '--progress', '--force']
+    const args = ['-c advice.detachedHead=false', 'checkout', '--progress', '--force']
     if (startPoint) {
       args.push('-B', ref, startPoint)
     } else {


### PR DESCRIPTION
Checking out certain `ref` values will result in a warning about a detached `HEAD`:
```
You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false
```

However, this warning isn't useful in a CI environment... so suppress it.

I realize on the original bug report that one user mentioned this warning highlighted a bug in his actions flow, but I consider that a super rare / happy accident. 99% of use cases will be _intentionally_ checking out a specific ref where the detached head state is inevitable, so the warning is pure noise.

Passing the config this way sets it _only_ for this command. Note that it must be set [_before_ calling `checkout`](https://stackoverflow.com/a/72588008/770425).

Resolve: https://github.com/actions/checkout/issues/494