### PR TITLE
Replace datadog/squid with ubuntu/squid Docker image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,7 @@ jobs:
       options: --dns 127.0.0.1
     services:
       squid-proxy:
-        image: datadog/squid:latest
+        image: ubuntu/squid:latest
         ports:
           - 3128:3128
     env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+## Submitting a pull request
+
+1. Fork and clone the repository
+1. Configure and install the dependencies: `npm install`
+1. Create a new branch: `git checkout -b my-branch-name`
+1. Make your change, add tests, and make sure the tests still pass: `npm run test`
+1. Make sure your code is correctly formatted: `npm run format`
+1. Update `dist/index.js` using `npm run build`. This creates a single javascript file that is used as an entrypoint for the action
+1. Push to your fork and [submit a pull request][pr]
+1. Pat yourself on the back and wait for your pull request to be reviewed and merged.
+
+Here are a few things you can do that will increase the likelihood of your pull request being accepted:
+
+- Write tests.
+- Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
+
+## Resources
+
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
+- [GitHub Help](https://help.github.com)
+- [Writing good commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+
+Thanks! :heart: :heart: :heart:
+
+GitHub Actions Team :octocat:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@
 1. Make your change, add tests, and make sure the tests still pass: `npm run test`
 1. Make sure your code is correctly formatted: `npm run format`
 1. Update `dist/index.js` using `npm run build`. This creates a single javascript file that is used as an entrypoint for the action
-1. Push to your fork and [submit a pull request][pr]
-1. Pat yourself on the back and wait for your pull request to be reviewed and merged.
+1. Push to your fork and submit a pull request
+1. Pat yourself on the back and wait for your pull request to be reviewed and merged
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 


### PR DESCRIPTION
Our CI relied on `datadog/squid` Docker image which has now been deleted.

I noticed we also don't have a contributing doc which explains to new contributors how to update the JS bundle. I've copied the relevant section from [actions/labeler](https://github.com/actions/labeler/blob/main/CONTRIBUTING.md) to get one started.