### PR TITLE
Add in explicit reference to private checkout options

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
     repository: my-org/my-tools
     path: my-tools
 ```
+> - If your secondary repository is private you will need to add the option noted in [Checkout multiple repos (private)](#Checkout-multiple-repos-private)
 
 ## Checkout multiple repos (nested)
 
@@ -168,6 +169,7 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
     repository: my-org/my-tools
     path: my-tools
 ```
+> - If your secondary repository is private you will need to add the option noted in [Checkout multiple repos (private)](#Checkout-multiple-repos-private)
 
 ## Checkout multiple repos (private)
 


### PR DESCRIPTION
Updated the README to link to the private repo checkout and be explicit about it.

Fixes #1021 