### PR TITLE
removeGitConfig should follow nested submodule setting for not

### DIFF
--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -368,7 +368,7 @@ class GitAuthHelper {
     await this.git.submoduleForeach(
       // wrap the pipeline in quotes to make sure it's handled properly by submoduleForeach, rather than just the first part of the pipeline
       `sh -c "git config --local --name-only --get-regexp '${pattern}' && git config --local --unset-all '${configKey}' || :"`,
-      true
+      this.settings.nestedSubmodules
     )
   }
 }


### PR DESCRIPTION
`removeGitConfig` didn't follow the `nestedSubmodule`

```
Error: fatal: No url found for submodule path '***********' in .gitmodules
Error: fatal: run_command returned non-zero status while recursing in the nested submodules of buildroot
```