### PR TITLE
Take global core.sshCommand into consideration

### DIFF
--- a/__test__/git-directory-helper.test.ts
+++ b/__test__/git-directory-helper.test.ts
@@ -407,6 +407,7 @@ async function setup(testName: string): Promise<void> {
     checkoutDetach: jest.fn(),
     config: jest.fn(),
     configExists: jest.fn(),
+    configGet: jest.fn(),
     fetch: jest.fn(),
     getDefaultBranch: jest.fn(),
     getWorkingDirectory: jest.fn(() => repositoryPath),

--- a/dist/index.js
+++ b/dist/index.js
@@ -7253,7 +7253,9 @@ class GitAuthHelper {
             stateHelper.setSshKnownHostsPath(this.sshKnownHostsPath);
             yield fs.promises.writeFile(this.sshKnownHostsPath, knownHosts);
             // Configure GIT_SSH_COMMAND
-            const sshPath = yield io.which('ssh', true);
+            const sshPath = (yield this.git.configExists(SSH_COMMAND_KEY, true))
+                ? yield this.git.configGet(SSH_COMMAND_KEY, true)
+                : yield io.which('ssh', true);
             this.sshCommand = `"${sshPath}" -i "$RUNNER_TEMP/${path.basename(this.sshKeyPath)}"`;
             if (this.settings.sshStrict) {
                 this.sshCommand += ' -o StrictHostKeyChecking=yes -o CheckHostIP=no';
@@ -7531,6 +7533,16 @@ class GitCommandManager {
                 pattern
             ], true);
             return output.exitCode === 0;
+        });
+    }
+    configGet(configKey, globalConfig) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const output = yield this.execGit([
+                'config',
+                globalConfig ? '--global' : '--local',
+                configKey
+            ]);
+            return output.stdout.trim();
         });
     }
     fetch(refSpec, fetchDepth) {

--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -253,7 +253,9 @@ class GitAuthHelper {
     await fs.promises.writeFile(this.sshKnownHostsPath, knownHosts)
 
     // Configure GIT_SSH_COMMAND
-    const sshPath = await io.which('ssh', true)
+    const sshPath = (await this.git.configExists(SSH_COMMAND_KEY, true))
+      ? await this.git.configGet(SSH_COMMAND_KEY, true)
+      : await io.which('ssh', true)
     this.sshCommand = `"${sshPath}" -i "$RUNNER_TEMP/${path.basename(
       this.sshKeyPath
     )}"`

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -26,6 +26,7 @@ export interface IGitCommandManager {
   ): Promise<void>
   configExists(configKey: string, globalConfig?: boolean): Promise<boolean>
   fetch(refSpec: string[], fetchDepth?: number): Promise<void>
+  configGet(configKey: string, globalConfig?: boolean): Promise<string>
   getDefaultBranch(repositoryUrl: string): Promise<string>
   getWorkingDirectory(): string
   init(): Promise<void>
@@ -199,6 +200,15 @@ class GitCommandManager {
       true
     )
     return output.exitCode === 0
+  }
+
+  async configGet(configKey: string, globalConfig?: boolean): Promise<string> {
+    const output = await this.execGit([
+      'config',
+      globalConfig ? '--global' : '--local',
+      configKey
+    ])
+    return output.stdout.trim()
   }
 
   async fetch(refSpec: string[], fetchDepth?: number): Promise<void> {


### PR DESCRIPTION
git-auth-helper.ts overwrites core.sshCommand to pass custom parameters to ssh, but in doing so, it [overwrites the base command](https://github.com/actions/checkout/blob/bf085276cecdb0cc76fbbe0687a5a0e786646936/src/git-auth-helper.ts#L256) with the output of `io.which('ssh', true)`, which I assume just looks for ssh in the path; if the git configuration specifies a custom ssh command, git-auth-helper.ts should instead append custom parameters to the existing custom command.
