### PR TITLE
Support fetching without the --progress option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
     # Default: false
     fetch-tags: ''
 
+    # Whether to show progress status output when fetching.
+    # Default: true
+    show-progress: ''
+
     # Whether to download Git-LFS files
     # Default: false
     lfs: ''

--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -806,6 +806,7 @@ async function setup(testName: string): Promise<void> {
     sparseCheckoutConeMode: true,
     fetchDepth: 1,
     fetchTags: false,
+    showProgress: true,
     lfs: false,
     submodules: false,
     nestedSubmodules: false,

--- a/__test__/git-command-manager.test.ts
+++ b/__test__/git-command-manager.test.ts
@@ -135,7 +135,6 @@ describe('Test fetchDepth and fetchTags options', () => {
         'protocol.version=2',
         'fetch',
         '--prune',
-        '--progress',
         '--no-recurse-submodules',
         '--filter=filterValue',
         'origin',
@@ -174,7 +173,6 @@ describe('Test fetchDepth and fetchTags options', () => {
         'fetch',
         '--no-tags',
         '--prune',
-        '--progress',
         '--no-recurse-submodules',
         '--filter=filterValue',
         'origin',
@@ -213,7 +211,6 @@ describe('Test fetchDepth and fetchTags options', () => {
         'fetch',
         '--no-tags',
         '--prune',
-        '--progress',
         '--no-recurse-submodules',
         '--filter=filterValue',
         '--depth=1',
@@ -252,10 +249,125 @@ describe('Test fetchDepth and fetchTags options', () => {
         'protocol.version=2',
         'fetch',
         '--prune',
-        '--progress',
         '--no-recurse-submodules',
         '--filter=filterValue',
         '--depth=1',
+        'origin',
+        'refspec1',
+        'refspec2'
+      ],
+      expect.any(Object)
+    )
+  })
+
+  it('should call execGit with the correct arguments when showProgress is true', async () => {
+    jest.spyOn(exec, 'exec').mockImplementation(mockExec)
+
+    const workingDirectory = 'test'
+    const lfs = false
+    const doSparseCheckout = false
+    git = await commandManager.createCommandManager(
+      workingDirectory,
+      lfs,
+      doSparseCheckout
+    )
+    const refSpec = ['refspec1', 'refspec2']
+    const options = {
+      filter: 'filterValue',
+      showProgress: true
+    }
+
+    await git.fetch(refSpec, options)
+
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.any(String),
+      [
+        '-c',
+        'protocol.version=2',
+        'fetch',
+        '--no-tags',
+        '--prune',
+        '--no-recurse-submodules',
+        '--progress',
+        '--filter=filterValue',
+        'origin',
+        'refspec1',
+        'refspec2'
+      ],
+      expect.any(Object)
+    )
+  })
+
+  it('should call execGit with the correct arguments when fetchDepth is 42 and showProgress is true', async () => {
+    jest.spyOn(exec, 'exec').mockImplementation(mockExec)
+
+    const workingDirectory = 'test'
+    const lfs = false
+    const doSparseCheckout = false
+    git = await commandManager.createCommandManager(
+      workingDirectory,
+      lfs,
+      doSparseCheckout
+    )
+    const refSpec = ['refspec1', 'refspec2']
+    const options = {
+      filter: 'filterValue',
+      fetchDepth: 42,
+      showProgress: true
+    }
+
+    await git.fetch(refSpec, options)
+
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.any(String),
+      [
+        '-c',
+        'protocol.version=2',
+        'fetch',
+        '--no-tags',
+        '--prune',
+        '--no-recurse-submodules',
+        '--progress',
+        '--filter=filterValue',
+        '--depth=42',
+        'origin',
+        'refspec1',
+        'refspec2'
+      ],
+      expect.any(Object)
+    )
+  })
+
+  it('should call execGit with the correct arguments when fetchTags is true and showProgress is true', async () => {
+    jest.spyOn(exec, 'exec').mockImplementation(mockExec)
+
+    const workingDirectory = 'test'
+    const lfs = false
+    const doSparseCheckout = false
+    git = await commandManager.createCommandManager(
+      workingDirectory,
+      lfs,
+      doSparseCheckout
+    )
+    const refSpec = ['refspec1', 'refspec2']
+    const options = {
+      filter: 'filterValue',
+      fetchTags: true,
+      showProgress: true
+    }
+
+    await git.fetch(refSpec, options)
+
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.any(String),
+      [
+        '-c',
+        'protocol.version=2',
+        'fetch',
+        '--prune',
+        '--no-recurse-submodules',
+        '--progress',
+        '--filter=filterValue',
         'origin',
         'refspec1',
         'refspec2'

--- a/__test__/input-helper.test.ts
+++ b/__test__/input-helper.test.ts
@@ -83,6 +83,7 @@ describe('input-helper tests', () => {
     expect(settings.sparseCheckoutConeMode).toBe(true)
     expect(settings.fetchDepth).toBe(1)
     expect(settings.fetchTags).toBe(false)
+    expect(settings.showProgress).toBe(true)
     expect(settings.lfs).toBe(false)
     expect(settings.ref).toBe('refs/heads/some-ref')
     expect(settings.repositoryName).toBe('some-repo')

--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,9 @@ inputs:
   fetch-tags:
     description: 'Whether to fetch tags, even if fetch-depth > 0.'
     default: false
+  show-progress:
+    description: 'Whether to show progress status output when fetching.'
+    default: true
   lfs:
     description: 'Whether to download Git-LFS files'
     default: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -640,7 +640,10 @@ class GitCommandManager {
             if (!refSpec.some(x => x === refHelper.tagsRefSpec) && !options.fetchTags) {
                 args.push('--no-tags');
             }
-            args.push('--prune', '--progress', '--no-recurse-submodules');
+            args.push('--prune', '--no-recurse-submodules');
+            if (options.showProgress) {
+                args.push('--progress');
+            }
             if (options.filter) {
                 args.push(`--filter=${options.filter}`);
             }
@@ -1739,6 +1742,10 @@ function getInputs() {
         result.fetchTags =
             (core.getInput('fetch-tags') || 'false').toUpperCase() === 'TRUE';
         core.debug(`fetch tags = ${result.fetchTags}`);
+        // Show fetch progress
+        result.showProgress =
+            (core.getInput('show-progress') || 'true').toUpperCase() === 'TRUE';
+        core.debug(`show progress = ${result.showProgress}`);
         // LFS
         result.lfs = (core.getInput('lfs') || 'false').toUpperCase() === 'TRUE';
         core.debug(`lfs = ${result.lfs}`);

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -34,6 +34,7 @@ export interface IGitCommandManager {
       filter?: string
       fetchDepth?: number
       fetchTags?: boolean
+      showProgress?: boolean
     }
   ): Promise<void>
   getDefaultBranch(repositoryUrl: string): Promise<string>
@@ -241,14 +242,22 @@ class GitCommandManager {
 
   async fetch(
     refSpec: string[],
-    options: {filter?: string; fetchDepth?: number; fetchTags?: boolean}
+    options: {
+      filter?: string
+      fetchDepth?: number
+      fetchTags?: boolean
+      showProgress?: boolean
+    }
   ): Promise<void> {
     const args = ['-c', 'protocol.version=2', 'fetch']
     if (!refSpec.some(x => x === refHelper.tagsRefSpec) && !options.fetchTags) {
       args.push('--no-tags')
     }
 
-    args.push('--prune', '--progress', '--no-recurse-submodules')
+    args.push('--prune', '--no-recurse-submodules')
+    if (options.showProgress) {
+      args.push('--progress')
+    }
 
     if (options.filter) {
       args.push(`--filter=${options.filter}`)

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -157,6 +157,7 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
       filter?: string
       fetchDepth?: number
       fetchTags?: boolean
+      showProgress?: boolean
     } = {}
     if (settings.sparseCheckout) fetchOptions.filter = 'blob:none'
     if (settings.fetchDepth <= 0) {

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -50,6 +50,11 @@ export interface IGitSourceSettings {
   fetchTags: boolean
 
   /**
+   * Indicates whether to use the --progress option when fetching
+   */
+  showProgress: boolean
+
+  /**
    * Indicates whether to fetch LFS objects
    */
   lfs: boolean

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -105,6 +105,11 @@ export async function getInputs(): Promise<IGitSourceSettings> {
     (core.getInput('fetch-tags') || 'false').toUpperCase() === 'TRUE'
   core.debug(`fetch tags = ${result.fetchTags}`)
 
+  // Show fetch progress
+  result.showProgress =
+    (core.getInput('show-progress') || 'true').toUpperCase() === 'TRUE'
+  core.debug(`show progress = ${result.showProgress}`)
+
   // LFS
   result.lfs = (core.getInput('lfs') || 'false').toUpperCase() === 'TRUE'
   core.debug(`lfs = ${result.lfs}`)


### PR DESCRIPTION
If this is merged, setting the `progress` option to false in the `with` section of the workflow step will cause git fetch to run without the `--progress` flag.

Note that the default value of this new option is `true`, which matches the current behavior, so this PR introduces no behavior change unless the new option is explicitly present and set to false.

The motivation is to be able to suppress the noisy progress status output which adds many hundreds of `remote: Counting objects: 85% (386/453)` and similar lines in the workflow log.

This should be sufficient to resolve #894 and its older friends, though the solution is different to the one proposed there because it doesn't use the `--quiet` flag. IIUC git doesn't show the progress status by default when running on GitHub since the output is not a terminal. Adding the `--progress` flag is what forces the progress output to be shown, so that's why removing it is all that's needed.

Adding the `--quiet` flag doesn't make a lot of difference once the `--progress` flag is removed, and actually I think using `--quiet` would suppress some other more useful output that would be better left visible.
