### PR TITLE
docs: fix missing quotes around fetch-depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This action checks-out your repository under `$GITHUB_WORKSPACE`, so your workflow can access it.
 
-Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Set `fetch-depth: 0` to fetch all history for all branches and tags. Refer [here](https://help.github.com/en/articles/events-that-trigger-workflows) to learn which commit `$GITHUB_SHA` points to for different events.
+Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Set `fetch-depth: '0'` to fetch all history for all branches and tags. Refer [here](https://help.github.com/en/articles/events-that-trigger-workflows) to learn which commit `$GITHUB_SHA` points to for different events.
 
 The auth token is persisted in the local git config. This enables your scripts to run authenticated git commands. The token is removed during post-job cleanup. Set `persist-credentials: false` to opt-out.
 


### PR DESCRIPTION
Fix missing quotes around fetch-depth in README.md.

Notes: Example showing fetch-depth not work without quotes and working with.
https://github.com/hxtree/cats-cradle/actions/runs/4149479127/jobs/7178456295#step:6:69
https://github.com/hxtree/cats-cradle/actions/runs/4149593021/jobs/7178650959

This is misleading as it is in the the intro in a manner that doesn't work.