### PR TITLE
README: Suggest `user.email` to be `41898282+github-actions[bot]@users.noreply.github.com`

### DIFF
--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -22,8 +22,8 @@ jobs:
         fetch-depth: 0
     - name: Git config
       run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
     - name: Tag new target
       run: git tag -f ${{ github.event.inputs.main_version }} ${{ github.event.inputs.target }}
     - name: Push new tag

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Git config
       run: |
         git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
     - name: Tag new target
       run: git tag -f ${{ github.event.inputs.main_version }} ${{ github.event.inputs.target }}
     - name: Push new tag

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ jobs:
       - run: |
           date > generated.txt
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "generated"
           git push

--- a/README.md
+++ b/README.md
@@ -223,8 +223,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           date > generated.txt
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "generated"
           git push


### PR DESCRIPTION
To get a proper GitHub Actions Bot annotation to a commit one should set the `user.name` and `user.email` to:

```bash
git config user.name "github-actions[bot]"
git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
```

There are some confusion around this in the `actions/` org itself:

* [**actions/toolkit**/.github/workflows/update-github.yam](https://github.com/actions/toolkit/blob/0db3029fcfcb1393a2b3ccd14caecd7a3460af4e/.github/workflows/update-github.yaml#L24) uses `github-actions[bot]` + `github-actions@github.com` which [does not give a proper avatar on the commit](https://github.com/actions/toolkit/pull/751/commits/d3ad3eeb7f015447f6b9663d1b66995e577776c3)
* [**actions/deploy-pages**/.github/workflows/rebuild-dependabot-prs.yml](https://github.com/actions/deploy-pages/blob/ff669327f73994ba35f45d1cd2fc81d82d1c852c/.github/workflows/rebuild-dependabot-prs.yml#L43-L44) uses the setup suggested in this PR (`github-actions[bot]` + `github-actions[bot]@users.noreply.github.com`) apart from lacking the `41898282+` prefix to the email
* [**actions/runner-images**/.github/workflows/merge_pull_request.yml](https://github.com/actions/runner-images/blob/7fa12b880649ddd0a00fed00b79a5bd4aed462ab/.github/workflows/merge_pull_request.yml#L19-L20) uses `Actions service account` + `no-reply@github.com`
* [**actions/actions-runner-controller**/.github/workflows/update-runners.yaml](https://github.com/actions/actions-runner-controller/blob/9b44f0051ca01556c10e6240f17bb21280be7e39/.github/workflows/update-runners.yaml#L99-L101) uses uses the exact same setup as suggested here, referencing [this discussion](https://github.com/orgs/community/discussions/26560#discussioncomment-3252339) as the source of why that is correct

(Another interesting aspect of the linked to workflows is that some use `--local` when setting the name and email, some use `--global` and some does what is suggested here and use neither of `--local` and `--global`)

Of note is also a third approach from the community, where it strives to achieve custom bot users (+ to get around the limitation of workflow created PR:s not running workflows): https://github.com/wow-actions/use-app-token Such a `env.BOT_NAME` would be quite nice to have built in to use.

An example generated with this setup can be found here: https://github.com/SocketDev/socket-sdk-js/pull/72/commits/24f05748ebcb527cf35dfa5c4cbc2b66d69a45f3

Generated with: https://github.com/SocketDev/workflows/blob/24190c5ca3aa54b086ff1666ed4486f6bc1e9ec9/.github/workflows/reusable-sync.yml#L118-L119

**EDIT:** Swapped the recommendation to include the prefix `41898282+` as I found out that that's the email used when the bot does eg. squash commits and thus its otherwise showing up as being two different users, which looks a bit confusing. See eg: https://github.com/SocketDev/socket-sdk-js/commit/b0948d0da0cfb5b240c69d063cc34a6399abce48