### PR TITLE
Change git config scope from global to system

### DIFF
--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -5,6 +5,7 @@ import * as io from '@actions/io'
 import * as os from 'os'
 import * as path from 'path'
 import * as stateHelper from '../lib/state-helper'
+import {ConfigScope} from '../lib/git-command-manager'
 import {IGitCommandManager} from '../lib/git-command-manager'
 import {IGitSourceSettings} from '../lib/git-source-settings'
 
@@ -730,16 +731,16 @@ async function setup(testName: string): Promise<void> {
     checkout: jest.fn(),
     checkoutDetach: jest.fn(),
     config: jest.fn(
-      async (key: string, value: string, globalConfig?: boolean) => {
-        const configPath = globalConfig
+      async (key: string, value: string, configScope?: ConfigScope) => {
+        const configPath = configScope
           ? path.join(git.env['HOME'] || tempHomedir, '.gitconfig')
           : localGitConfigPath
         await fs.promises.appendFile(configPath, `\n${key} ${value}`)
       }
     ),
     configExists: jest.fn(
-      async (key: string, globalConfig?: boolean): Promise<boolean> => {
-        const configPath = globalConfig
+      async (key: string, configScope?: ConfigScope): Promise<boolean> => {
+        const configPath = configScope
           ? path.join(git.env['HOME'] || tempHomedir, '.gitconfig')
           : localGitConfigPath
         const content = await fs.promises.readFile(configPath)
@@ -774,8 +775,8 @@ async function setup(testName: string): Promise<void> {
     tagExists: jest.fn(),
     tryClean: jest.fn(),
     tryConfigUnset: jest.fn(
-      async (key: string, globalConfig?: boolean): Promise<boolean> => {
-        const configPath = globalConfig
+      async (key: string, configScope?: ConfigScope): Promise<boolean> => {
+        const configPath = configScope
           ? path.join(git.env['HOME'] || tempHomedir, '.gitconfig')
           : localGitConfigPath
         let content = await fs.promises.readFile(configPath)

--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -136,7 +136,12 @@ class GitAuthHelper {
       await this.git.tryConfigUnset(this.insteadOfKey, ConfigScope.System)
       if (!this.settings.sshKey) {
         for (const insteadOfValue of this.insteadOfValues) {
-          await this.git.config(this.insteadOfKey, insteadOfValue, ConfigScope.System, true)
+          await this.git.config(
+            this.insteadOfKey,
+            insteadOfValue,
+            ConfigScope.System,
+            true
+          )
         }
       }
     } catch (err) {
@@ -294,7 +299,7 @@ class GitAuthHelper {
     await this.git.config(
       this.tokenConfigKey,
       this.tokenPlaceholderConfigValue,
-      configScope,
+      configScope
     )
 
     // Replace the placeholder

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -13,9 +13,9 @@ import {GitVersion} from './git-version'
 export const MinimumGitVersion = new GitVersion('2.18')
 
 export enum ConfigScope {
-  Local = "local",
-  Global = "global",
-  System = "system",
+  Local = 'local',
+  Global = 'global',
+  System = 'system'
 }
 
 export interface IGitCommandManager {
@@ -181,7 +181,10 @@ class GitCommandManager {
     configScope?: ConfigScope,
     add?: boolean
   ): Promise<void> {
-    const args: string[] = ['config', configScope ? `--${configScope}` : '--local']
+    const args: string[] = [
+      'config',
+      configScope ? `--${configScope}` : '--local'
+    ]
     if (add) {
       args.push('--add')
     }

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -9,6 +9,7 @@ import * as path from 'path'
 import * as refHelper from './ref-helper'
 import * as stateHelper from './state-helper'
 import * as urlHelper from './url-helper'
+import {ConfigScope} from './git-command-manager'
 import {IGitCommandManager} from './git-command-manager'
 import {IGitSourceSettings} from './git-source-settings'
 
@@ -49,7 +50,7 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
         )
 
         await git
-          .config('safe.directory', settings.repositoryPath, true, true)
+          .config('safe.directory', settings.repositoryPath, ConfigScope.System, true)
           .catch(error => {
             core.info(
               `Failed to initialize safe directory with error: ${error}`
@@ -278,7 +279,7 @@ export async function cleanup(repositoryPath: string): Promise<void> {
       )
 
       await git
-        .config('safe.directory', repositoryPath, true, true)
+        .config('safe.directory', repositoryPath, ConfigScope.System, true)
         .catch(error => {
           core.info(`Failed to initialize safe directory with error: ${error}`)
         })

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -50,7 +50,12 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
         )
 
         await git
-          .config('safe.directory', settings.repositoryPath, ConfigScope.System, true)
+          .config(
+            'safe.directory',
+            settings.repositoryPath,
+            ConfigScope.System,
+            true
+          )
           .catch(error => {
             core.info(
               `Failed to initialize safe directory with error: ${error}`


### PR DESCRIPTION
## Description

Fixes #1169 

The `/github/home/.gitconfig` does not seem to exist in the container even after `git checkout`. As a result, the project directory (with `.git` directory in it) will not be considered as a safe directory and any further *action* that relies on a `git` will fail.

This PR will change the scope of `git config` command from `global` to `system`.
