### PR TITLE
Set `user.signingKey` to `ssh-key`

### DIFF
--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -295,6 +295,10 @@ describe('git-auth-helper tests', () => {
       'core.sshCommand',
       expectedSshCommand
     )
+    expect(git.config).toHaveBeenCalledWith(
+      'user.signingKey',
+      actualKeyPath
+    )
   })
 
   const configureAuth_writesExplicitKnownHosts = 'writes explicit known hosts'

--- a/dist/index.js
+++ b/dist/index.js
@@ -148,6 +148,7 @@ const urlHelper = __importStar(__nccwpck_require__(9437));
 const v4_1 = __importDefault(__nccwpck_require__(824));
 const IS_WINDOWS = process.platform === 'win32';
 const SSH_COMMAND_KEY = 'core.sshCommand';
+const SIGNING_KEY = 'user.signingKey';
 function createAuthHelper(git, settings) {
     return new GitAuthHelper(git, settings);
 }
@@ -305,7 +306,7 @@ class GitAuthHelper {
             this.sshKeyPath = path.join(runnerTemp, uniqueId);
             stateHelper.setSshKeyPath(this.sshKeyPath);
             yield fs.promises.mkdir(runnerTemp, { recursive: true });
-            yield fs.promises.writeFile(this.sshKeyPath, this.settings.sshKey.trim() + '\n', { mode: 0o600 });
+            yield fs.promises.writeFile(this.sshKeyPath, `${this.settings.sshKey.trim()}\n`, { mode: 0o600 });
             // Remove inherited permissions on Windows
             if (IS_WINDOWS) {
                 const icacls = yield io.which('icacls.exe');
@@ -346,6 +347,7 @@ class GitAuthHelper {
             // Configure core.sshCommand
             if (this.settings.persistCredentials) {
                 yield this.git.config(SSH_COMMAND_KEY, this.sshCommand);
+                yield this.git.config(SIGNING_KEY, this.sshKeyPath);
             }
         });
     }

--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -14,6 +14,7 @@ import {IGitSourceSettings} from './git-source-settings'
 
 const IS_WINDOWS = process.platform === 'win32'
 const SSH_COMMAND_KEY = 'core.sshCommand'
+const SIGNING_KEY = 'user.signingKey'
 
 export interface IGitAuthHelper {
   configureAuth(): Promise<void>
@@ -269,6 +270,7 @@ class GitAuthHelper {
     // Configure core.sshCommand
     if (this.settings.persistCredentials) {
       await this.git.config(SSH_COMMAND_KEY, this.sshCommand)
+      await this.git.config(SIGNING_KEY, this.sshKeyPath)
     }
   }
 


### PR DESCRIPTION
Slightly simplifies reusing ssh key for signing commits and tags. Doesn't change `gpg.format`, to avoid breaking users of gpg keys .

Closes #1239.