### PR TITLE
Fix typos found by codespell

### DIFF
--- a/adrs/0153-checkout-v2.md
+++ b/adrs/0153-checkout-v2.md
@@ -181,7 +181,7 @@ GITHUB_WORKSPACE=/home/runner/work/foo/foo
 RUNNER_WORKSPACE=/home/runner/work/foo
 ```
 
-V2 introduces a new contraint on the checkout path. The location must now be under `github.workspace`. Whereas the checkout@v1 constraint was one level up, under `runner.workspace`.
+V2 introduces a new constraint on the checkout path. The location must now be under `github.workspace`. Whereas the checkout@v1 constraint was one level up, under `runner.workspace`.
 
 V2 no longer changes `github.workspace` to follow wherever the self repo is checked-out.
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1027,7 +1027,7 @@ function prepareExistingDirectory(git, repositoryPath, repositoryUrl, clean, ref
                 if (clean) {
                     core.startGroup('Cleaning the repository');
                     if (!(yield git.tryClean())) {
-                        core.debug(`The clean command failed. This might be caused by: 1) path too long, 2) permission issue, or 3) file in use. For futher investigation, manually run 'git clean -ffdx' on the directory '${repositoryPath}'.`);
+                        core.debug(`The clean command failed. This might be caused by: 1) path too long, 2) permission issue, or 3) file in use. For further investigation, manually run 'git clean -ffdx' on the directory '${repositoryPath}'.`);
                         remove = true;
                     }
                     else if (!(yield git.tryReset())) {

--- a/src/git-directory-helper.ts
+++ b/src/git-directory-helper.ts
@@ -86,7 +86,7 @@ export async function prepareExistingDirectory(
         core.startGroup('Cleaning the repository')
         if (!(await git.tryClean())) {
           core.debug(
-            `The clean command failed. This might be caused by: 1) path too long, 2) permission issue, or 3) file in use. For futher investigation, manually run 'git clean -ffdx' on the directory '${repositoryPath}'.`
+            `The clean command failed. This might be caused by: 1) path too long, 2) permission issue, or 3) file in use. For further investigation, manually run 'git clean -ffdx' on the directory '${repositoryPath}'.`
           )
           remove = true
         } else if (!(await git.tryReset())) {


### PR DESCRIPTION
Includes a change in an ADR (`0153-checkout-v2.md`). I can revert that change if you would rather not modify ADRs.