### PR TITLE
Pass correct baseUrl to octokit

### DIFF
--- a/__test__/github-api-helper.test.ts
+++ b/__test__/github-api-helper.test.ts
@@ -1,0 +1,37 @@
+import * as github from '@actions/github'
+import * as githubApiHelper from '../lib/github-api-helper'
+
+jest.mock('@actions/github')
+
+describe('github-api-helper tests', () => {
+  describe('github enterprise compatibility', () => {
+    beforeEach(() => {
+      process.env.GITHUB_SERVER_URL = 'https://enterprise.git.com'
+    })
+
+    afterEach(() => {
+      delete process.env.GITHUB_SERVER_URL
+    })
+
+    it('getDefaultBranch should use GITHUB_SERVER_URL to set the baseUrl', async () => {
+      ;(github.getOctokit as jest.Mock).mockImplementation(() => {
+        return {
+          rest: {
+            repos: {
+              get: jest.fn(() => ({data: {default_branch: 'default-branch'}}))
+            }
+          }
+        }
+      })
+
+      await githubApiHelper.getDefaultBranch('token', 'owner', 'repo')
+
+      expect(github.getOctokit).toHaveBeenCalledWith(
+        'token',
+        expect.objectContaining({
+          baseUrl: 'https://enterprise.git.com/api/v3'
+        })
+      )
+    })
+  })
+})

--- a/dist/index.js
+++ b/dist/index.js
@@ -1452,6 +1452,7 @@ const io = __importStar(__nccwpck_require__(7436));
 const path = __importStar(__nccwpck_require__(1017));
 const retryHelper = __importStar(__nccwpck_require__(2155));
 const toolCache = __importStar(__nccwpck_require__(7784));
+const url_helper_1 = __nccwpck_require__(9437);
 const v4_1 = __importDefault(__nccwpck_require__(824));
 const IS_WINDOWS = process.platform === 'win32';
 function downloadRepository(authToken, owner, repo, ref, commit, repositoryPath, baseUrl) {
@@ -1513,7 +1514,9 @@ function getDefaultBranch(authToken, owner, repo, baseUrl) {
         return yield retryHelper.execute(() => __awaiter(this, void 0, void 0, function* () {
             var _a;
             core.info('Retrieving the default branch name');
-            const octokit = github.getOctokit(authToken, { baseUrl: baseUrl });
+            const octokit = github.getOctokit(authToken, {
+                baseUrl: (0, url_helper_1.getServerApiUrl)(baseUrl)
+            });
             let result;
             try {
                 // Get the default branch from the repo info
@@ -1545,7 +1548,9 @@ function getDefaultBranch(authToken, owner, repo, baseUrl) {
 exports.getDefaultBranch = getDefaultBranch;
 function downloadArchive(authToken, owner, repo, ref, commit, baseUrl) {
     return __awaiter(this, void 0, void 0, function* () {
-        const octokit = github.getOctokit(authToken, { baseUrl: baseUrl });
+        const octokit = github.getOctokit(authToken, {
+            baseUrl: (0, url_helper_1.getServerApiUrl)(baseUrl)
+        });
         const download = IS_WINDOWS
             ? octokit.rest.repos.downloadZipballArchive
             : octokit.rest.repos.downloadTarballArchive;
@@ -2026,7 +2031,7 @@ function checkCommitInfo(token, commitInfo, repositoryOwner, repositoryName, ref
             if (actualHeadSha !== expectedHeadSha) {
                 core.debug(`Expected head sha ${expectedHeadSha}; actual head sha ${actualHeadSha}`);
                 const octokit = github.getOctokit(token, {
-                    baseUrl: baseUrl,
+                    baseUrl: (0, url_helper_1.getServerApiUrl)(baseUrl),
                     userAgent: `actions-checkout-tracepoint/1.0 (code=STALE_MERGE;owner=${repositoryOwner};repo=${repositoryName};pr=${fromPayload('number')};run_id=${process.env['GITHUB_RUN_ID']};expected_head_sha=${expectedHeadSha};actual_head_sha=${actualHeadSha})`
                 });
                 yield octokit.rest.repos.get({

--- a/src/github-api-helper.ts
+++ b/src/github-api-helper.ts
@@ -6,6 +6,7 @@ import * as io from '@actions/io'
 import * as path from 'path'
 import * as retryHelper from './retry-helper'
 import * as toolCache from '@actions/tool-cache'
+import {getServerApiUrl} from './url-helper'
 import {default as uuid} from 'uuid/v4'
 
 const IS_WINDOWS = process.platform === 'win32'
@@ -84,7 +85,9 @@ export async function getDefaultBranch(
 ): Promise<string> {
   return await retryHelper.execute(async () => {
     core.info('Retrieving the default branch name')
-    const octokit = github.getOctokit(authToken, {baseUrl: baseUrl})
+    const octokit = github.getOctokit(authToken, {
+      baseUrl: getServerApiUrl(baseUrl)
+    })
     let result: string
     try {
       // Get the default branch from the repo info
@@ -125,7 +128,9 @@ async function downloadArchive(
   commit: string,
   baseUrl?: string
 ): Promise<Buffer> {
-  const octokit = github.getOctokit(authToken, {baseUrl: baseUrl})
+  const octokit = github.getOctokit(authToken, {
+    baseUrl: getServerApiUrl(baseUrl)
+  })
   const download = IS_WINDOWS
     ? octokit.rest.repos.downloadZipballArchive
     : octokit.rest.repos.downloadTarballArchive

--- a/src/ref-helper.ts
+++ b/src/ref-helper.ts
@@ -1,7 +1,7 @@
 import {IGitCommandManager} from './git-command-manager'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
-import {isGhes} from './url-helper'
+import {getServerApiUrl, isGhes} from './url-helper'
 
 export const tagsRefSpec = '+refs/tags/*:refs/tags/*'
 
@@ -245,7 +245,7 @@ export async function checkCommitInfo(
         `Expected head sha ${expectedHeadSha}; actual head sha ${actualHeadSha}`
       )
       const octokit = github.getOctokit(token, {
-        baseUrl: baseUrl,
+        baseUrl: getServerApiUrl(baseUrl),
         userAgent: `actions-checkout-tracepoint/1.0 (code=STALE_MERGE;owner=${repositoryOwner};repo=${repositoryName};pr=${fromPayload(
           'number'
         )};run_id=${


### PR DESCRIPTION
The PR #1246 replaced the `getOctokit` method from the `octokit-provider.ts` file with the `getOctokit` method from the `@actions/github` package.
The octokit-provider was previously responsible for creating an Octokit instance and setting the `baseUrl` via the `getServerApiUrl` helper function. This function calls `getServerUrl` which reads the server url from the `GITHUB_SERVER_URL` environment variable, which on GHES is set to the enterprise instance.
This commit restores the previous behaviour by calling `getServerApiUrl` in all places where an octokit instance is created.