### PR TITLE
Fix: convert baseUrl to serverApiUrl 'formatted'

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1514,7 +1514,9 @@ function getDefaultBranch(authToken, owner, repo, baseUrl) {
         return yield retryHelper.execute(() => __awaiter(this, void 0, void 0, function* () {
             var _a;
             core.info('Retrieving the default branch name');
-            const octokit = github.getOctokit(authToken, { baseUrl: (0, url_helper_1.getServerApiUrl)(baseUrl) });
+            const octokit = github.getOctokit(authToken, {
+                baseUrl: (0, url_helper_1.getServerApiUrl)(baseUrl)
+            });
             let result;
             try {
                 // Get the default branch from the repo info
@@ -1546,7 +1548,9 @@ function getDefaultBranch(authToken, owner, repo, baseUrl) {
 exports.getDefaultBranch = getDefaultBranch;
 function downloadArchive(authToken, owner, repo, ref, commit, baseUrl) {
     return __awaiter(this, void 0, void 0, function* () {
-        const octokit = github.getOctokit(authToken, { baseUrl: (0, url_helper_1.getServerApiUrl)(baseUrl) });
+        const octokit = github.getOctokit(authToken, {
+            baseUrl: (0, url_helper_1.getServerApiUrl)(baseUrl)
+        });
         const download = IS_WINDOWS
             ? octokit.rest.repos.downloadZipballArchive
             : octokit.rest.repos.downloadTarballArchive;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1453,6 +1453,7 @@ const path = __importStar(__nccwpck_require__(1017));
 const retryHelper = __importStar(__nccwpck_require__(2155));
 const toolCache = __importStar(__nccwpck_require__(7784));
 const v4_1 = __importDefault(__nccwpck_require__(824));
+const url_helper_1 = __nccwpck_require__(9437);
 const IS_WINDOWS = process.platform === 'win32';
 function downloadRepository(authToken, owner, repo, ref, commit, repositoryPath, baseUrl) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -1513,7 +1514,7 @@ function getDefaultBranch(authToken, owner, repo, baseUrl) {
         return yield retryHelper.execute(() => __awaiter(this, void 0, void 0, function* () {
             var _a;
             core.info('Retrieving the default branch name');
-            const octokit = github.getOctokit(authToken, { baseUrl: baseUrl });
+            const octokit = github.getOctokit(authToken, { baseUrl: (0, url_helper_1.getServerApiUrl)(baseUrl) });
             let result;
             try {
                 // Get the default branch from the repo info
@@ -1545,7 +1546,7 @@ function getDefaultBranch(authToken, owner, repo, baseUrl) {
 exports.getDefaultBranch = getDefaultBranch;
 function downloadArchive(authToken, owner, repo, ref, commit, baseUrl) {
     return __awaiter(this, void 0, void 0, function* () {
-        const octokit = github.getOctokit(authToken, { baseUrl: baseUrl });
+        const octokit = github.getOctokit(authToken, { baseUrl: (0, url_helper_1.getServerApiUrl)(baseUrl) });
         const download = IS_WINDOWS
             ? octokit.rest.repos.downloadZipballArchive
             : octokit.rest.repos.downloadTarballArchive;
@@ -2026,7 +2027,7 @@ function checkCommitInfo(token, commitInfo, repositoryOwner, repositoryName, ref
             if (actualHeadSha !== expectedHeadSha) {
                 core.debug(`Expected head sha ${expectedHeadSha}; actual head sha ${actualHeadSha}`);
                 const octokit = github.getOctokit(token, {
-                    baseUrl: baseUrl,
+                    baseUrl: (0, url_helper_1.getServerApiUrl)(baseUrl),
                     userAgent: `actions-checkout-tracepoint/1.0 (code=STALE_MERGE;owner=${repositoryOwner};repo=${repositoryName};pr=${fromPayload('number')};run_id=${process.env['GITHUB_RUN_ID']};expected_head_sha=${expectedHeadSha};actual_head_sha=${actualHeadSha})`
                 });
                 yield octokit.rest.repos.get({

--- a/src/github-api-helper.ts
+++ b/src/github-api-helper.ts
@@ -7,6 +7,7 @@ import * as path from 'path'
 import * as retryHelper from './retry-helper'
 import * as toolCache from '@actions/tool-cache'
 import {default as uuid} from 'uuid/v4'
+import {getServerApiUrl} from './url-helper'
 
 const IS_WINDOWS = process.platform === 'win32'
 
@@ -84,7 +85,7 @@ export async function getDefaultBranch(
 ): Promise<string> {
   return await retryHelper.execute(async () => {
     core.info('Retrieving the default branch name')
-    const octokit = github.getOctokit(authToken, {baseUrl: baseUrl})
+    const octokit = github.getOctokit(authToken, {baseUrl: getServerApiUrl(baseUrl)})
     let result: string
     try {
       // Get the default branch from the repo info
@@ -125,7 +126,7 @@ async function downloadArchive(
   commit: string,
   baseUrl?: string
 ): Promise<Buffer> {
-  const octokit = github.getOctokit(authToken, {baseUrl: baseUrl})
+  const octokit = github.getOctokit(authToken, {baseUrl: getServerApiUrl(baseUrl)})
   const download = IS_WINDOWS
     ? octokit.rest.repos.downloadZipballArchive
     : octokit.rest.repos.downloadTarballArchive

--- a/src/github-api-helper.ts
+++ b/src/github-api-helper.ts
@@ -85,7 +85,9 @@ export async function getDefaultBranch(
 ): Promise<string> {
   return await retryHelper.execute(async () => {
     core.info('Retrieving the default branch name')
-    const octokit = github.getOctokit(authToken, {baseUrl: getServerApiUrl(baseUrl)})
+    const octokit = github.getOctokit(authToken, {
+      baseUrl: getServerApiUrl(baseUrl)
+    })
     let result: string
     try {
       // Get the default branch from the repo info
@@ -126,7 +128,9 @@ async function downloadArchive(
   commit: string,
   baseUrl?: string
 ): Promise<Buffer> {
-  const octokit = github.getOctokit(authToken, {baseUrl: getServerApiUrl(baseUrl)})
+  const octokit = github.getOctokit(authToken, {
+    baseUrl: getServerApiUrl(baseUrl)
+  })
   const download = IS_WINDOWS
     ? octokit.rest.repos.downloadZipballArchive
     : octokit.rest.repos.downloadTarballArchive

--- a/src/ref-helper.ts
+++ b/src/ref-helper.ts
@@ -1,7 +1,7 @@
 import {IGitCommandManager} from './git-command-manager'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
-import {isGhes} from './url-helper'
+import {getServerApiUrl, isGhes} from './url-helper'
 
 export const tagsRefSpec = '+refs/tags/*:refs/tags/*'
 
@@ -245,7 +245,7 @@ export async function checkCommitInfo(
         `Expected head sha ${expectedHeadSha}; actual head sha ${actualHeadSha}`
       )
       const octokit = github.getOctokit(token, {
-        baseUrl: baseUrl,
+        baseUrl: getServerApiUrl(baseUrl),
         userAgent: `actions-checkout-tracepoint/1.0 (code=STALE_MERGE;owner=${repositoryOwner};repo=${repositoryName};pr=${fromPayload(
           'number'
         )};run_id=${


### PR DESCRIPTION
Using the new version of the github package no longer implicitly translates [api.github.com](http://api.github.com/) into the GHES equvivalent.

This PR fixes the bug introduced in #1246 