### PR TITLE
Add support for sparse checkout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Sparse checkout basic example
         uses: ./
         with:
-          sparse-checkout: .
+          sparse-checkout: __test__
       - name: Verify sparse checkout basic
         run: __test__/verify-sparse-checkout-basic.sh
 
@@ -126,6 +126,7 @@ jobs:
         uses: ./
         with:
           sparse-checkout: |
+            __test__
             .github
             src
       - name: Verify sparse checkout basic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,20 @@ jobs:
         shell: bash
         run: __test__/verify-side-by-side.sh
 
+     # Sparse checkout
+      - name: Sparse checkout
+        uses: ./
+        with:
+          sparse-checkout: |
+            __test__
+            .github
+            dist
+
+      - name: Verify sparse checkout basic
+        run: __test__/verify-sparse-checkout-basic.sh
+      - name: Verify sparse checkout example
+        run: __test__/verify-sparse-checkout.sh
+
       # LFS
       - name: Checkout LFS
         uses: ./
@@ -112,19 +126,6 @@ jobs:
           submodules: recursive
       - name: Verify submodules recursive
         run: __test__/verify-submodules-recursive.sh
-
-     # Sparse checkout
-      - name: Sparse checkout
-        uses: ./
-        with:
-          sparse-checkout: |
-            __test__
-            .github
-            dist
-      - name: Verify sparse checkout basic
-        run: __test__/verify-sparse-checkout-basic.sh
-      - name: Verify sparse checkout example
-        run: __test__/verify-sparse-checkout.sh
 
       # Basic checkout using REST API
       - name: Remove basic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,26 @@ jobs:
       - name: Verify submodules recursive
         run: __test__/verify-submodules-recursive.sh
 
+      # Sparse checkout basic example
+      - name: Sparse checkout basic example
+        uses: ./
+        with:
+          sparse-checkout: .
+      - name: Verify sparse checkout basic
+        run: __test__/verify-sparse-checkout-basic.sh
+
+     # Sparse checkout example
+      - name: Sparse checkout example
+        uses: ./
+        with:
+          sparse-checkout: |
+            .github
+            src
+      - name: Verify sparse checkout basic
+        run: __test__/verify-sparse-checkout-basic.sh
+      - name: Verify sparse checkout example
+        run: __test__/verify-sparse-checkout.sh
+
       # Basic checkout using REST API
       - name: Remove basic
         if: runner.os != 'windows'
@@ -205,7 +225,7 @@ jobs:
           path: basic
       - name: Verify basic
         run: __test__/verify-basic.sh --archive
-    
+
   test-git-container:
     runs-on: ubuntu-latest
     container: bitnami/git:latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,22 +113,14 @@ jobs:
       - name: Verify submodules recursive
         run: __test__/verify-submodules-recursive.sh
 
-      # Sparse checkout basic example
-      - name: Sparse checkout basic example
-        uses: ./
-        with:
-          sparse-checkout: __test__
-      - name: Verify sparse checkout basic
-        run: __test__/verify-sparse-checkout-basic.sh
-
-     # Sparse checkout example
-      - name: Sparse checkout example
+     # Sparse checkout
+      - name: Sparse checkout
         uses: ./
         with:
           sparse-checkout: |
             __test__
             .github
-            src
+            dist
       - name: Verify sparse checkout basic
         run: __test__/verify-sparse-checkout-basic.sh
       - name: Verify sparse checkout example

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,7 @@ jobs:
             __test__
             .github
             dist
+          path: sparse-checkout
 
       - name: Verify sparse checkout basic
         run: __test__/verify-sparse-checkout-basic.sh

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
     # Default: true
     clean: ''
 
+    # Do a sparse checkout on given patterns (each pattern should be sepparated with new lines).
+    # Default: null
+    sparse-checkout: ''
+
     # Number of commits to fetch. 0 indicates all history for all branches and tags.
     # Default: 1
     fetch-depth: ''
@@ -106,15 +110,35 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
 
 # Scenarios
 
-- [Fetch all history for all tags and branches](#Fetch-all-history-for-all-tags-and-branches)
-- [Checkout a different branch](#Checkout-a-different-branch)
-- [Checkout HEAD^](#Checkout-HEAD)
-- [Checkout multiple repos (side by side)](#Checkout-multiple-repos-side-by-side)
-- [Checkout multiple repos (nested)](#Checkout-multiple-repos-nested)
-- [Checkout multiple repos (private)](#Checkout-multiple-repos-private)
-- [Checkout pull request HEAD commit instead of merge commit](#Checkout-pull-request-HEAD-commit-instead-of-merge-commit)
-- [Checkout pull request on closed event](#Checkout-pull-request-on-closed-event)
-- [Push a commit using the built-in token](#Push-a-commit-using-the-built-in-token)
+- [Fetch only the root files](#fetch-only-the-root-files)
+- [Fetch only the root files and `.github` and `src` folder](#fetch-only-the-root-files-and-github-and-src-folder)
+- [Fetch all history for all tags and branches](#fetch-all-history-for-all-tags-and-branches)
+- [Checkout a different branch](#checkout-a-different-branch)
+- [Checkout HEAD^](#checkout-head)
+- [Checkout multiple repos (side by side)](#checkout-multiple-repos-side-by-side)
+- [Checkout multiple repos (nested)](#checkout-multiple-repos-nested)
+- [Checkout multiple repos (private)](#checkout-multiple-repos-private)
+- [Checkout pull request HEAD commit instead of merge commit](#checkout-pull-request-head-commit-instead-of-merge-commit)
+- [Checkout pull request on closed event](#checkout-pull-request-on-closed-event)
+- [Push a commit using the built-in token](#push-a-commit-using-the-built-in-token)
+
+## Fetch only the root files
+
+```yaml
+- uses: actions/checkout@v3
+  with:
+    sparse-checkout: .
+```
+
+## Fetch only the root files and `.github` and `src` folder
+
+```yaml
+- uses: actions/checkout@v3
+  with:
+    sparse-checkout: |
+      .github
+      src
+```
 
 ## Fetch all history for all tags and branches
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
     # Default: true
     clean: ''
 
-    # Do a sparse checkout on given patterns (each pattern should be sepparated with new lines).
+    # Do a sparse checkout on given patterns
+    # Each pattern should be sepparated with new lines
     # Default: null
     sparse-checkout: ''
 
@@ -110,17 +111,22 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
 
 # Scenarios
 
-- [Fetch only the root files](#fetch-only-the-root-files)
-- [Fetch only the root files and `.github` and `src` folder](#fetch-only-the-root-files-and-github-and-src-folder)
-- [Fetch all history for all tags and branches](#fetch-all-history-for-all-tags-and-branches)
-- [Checkout a different branch](#checkout-a-different-branch)
-- [Checkout HEAD^](#checkout-head)
-- [Checkout multiple repos (side by side)](#checkout-multiple-repos-side-by-side)
-- [Checkout multiple repos (nested)](#checkout-multiple-repos-nested)
-- [Checkout multiple repos (private)](#checkout-multiple-repos-private)
-- [Checkout pull request HEAD commit instead of merge commit](#checkout-pull-request-head-commit-instead-of-merge-commit)
-- [Checkout pull request on closed event](#checkout-pull-request-on-closed-event)
-- [Push a commit using the built-in token](#push-a-commit-using-the-built-in-token)
+- [Checkout V3](#checkout-v3)
+- [What's new](#whats-new)
+- [Usage](#usage)
+- [Scenarios](#scenarios)
+  - [Fetch only the root files](#fetch-only-the-root-files)
+  - [Fetch only the root files and `.github` and `src` folder](#fetch-only-the-root-files-and-github-and-src-folder)
+  - [Fetch all history for all tags and branches](#fetch-all-history-for-all-tags-and-branches)
+  - [Checkout a different branch](#checkout-a-different-branch)
+  - [Checkout HEAD^](#checkout-head)
+  - [Checkout multiple repos (side by side)](#checkout-multiple-repos-side-by-side)
+  - [Checkout multiple repos (nested)](#checkout-multiple-repos-nested)
+  - [Checkout multiple repos (private)](#checkout-multiple-repos-private)
+  - [Checkout pull request HEAD commit instead of merge commit](#checkout-pull-request-head-commit-instead-of-merge-commit)
+  - [Checkout pull request on closed event](#checkout-pull-request-on-closed-event)
+  - [Push a commit using the built-in token](#push-a-commit-using-the-built-in-token)
+- [License](#license)
 
 ## Fetch only the root files
 

--- a/README.md
+++ b/README.md
@@ -111,22 +111,17 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
 
 # Scenarios
 
-- [Checkout V3](#checkout-v3)
-- [What's new](#whats-new)
-- [Usage](#usage)
-- [Scenarios](#scenarios)
-  - [Fetch only the root files](#fetch-only-the-root-files)
-  - [Fetch only the root files and `.github` and `src` folder](#fetch-only-the-root-files-and-github-and-src-folder)
-  - [Fetch all history for all tags and branches](#fetch-all-history-for-all-tags-and-branches)
-  - [Checkout a different branch](#checkout-a-different-branch)
-  - [Checkout HEAD^](#checkout-head)
-  - [Checkout multiple repos (side by side)](#checkout-multiple-repos-side-by-side)
-  - [Checkout multiple repos (nested)](#checkout-multiple-repos-nested)
-  - [Checkout multiple repos (private)](#checkout-multiple-repos-private)
-  - [Checkout pull request HEAD commit instead of merge commit](#checkout-pull-request-head-commit-instead-of-merge-commit)
-  - [Checkout pull request on closed event](#checkout-pull-request-on-closed-event)
-  - [Push a commit using the built-in token](#push-a-commit-using-the-built-in-token)
-- [License](#license)
+- [Fetch only the root files](#fetch-only-the-root-files)
+- [Fetch only the root files and `.github` and `src` folder](#fetch-only-the-root-files-and-github-and-src-folder)
+- [Fetch all history for all tags and branches](#fetch-all-history-for-all-tags-and-branches)
+- [Checkout a different branch](#checkout-a-different-branch)
+- [Checkout HEAD^](#checkout-head)
+- [Checkout multiple repos (side by side)](#checkout-multiple-repos-side-by-side)
+- [Checkout multiple repos (nested)](#checkout-multiple-repos-nested)
+- [Checkout multiple repos (private)](#checkout-multiple-repos-private)
+- [Checkout pull request HEAD commit instead of merge commit](#checkout-pull-request-head-commit-instead-of-merge-commit)
+- [Checkout pull request on closed event](#checkout-pull-request-on-closed-event)
+- [Push a commit using the built-in token](#push-a-commit-using-the-built-in-token)
 
 ## Fetch only the root files
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
     # Default: true
     clean: ''
 
-    # Do a sparse checkout on given patterns
-    # Each pattern should be sepparated with new lines
+    # Do a sparse checkout on given patterns. Each pattern should be sepparated with
+    # new lines
     # Default: null
     sparse-checkout: ''
 

--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -727,6 +727,7 @@ async function setup(testName: string): Promise<void> {
     branchDelete: jest.fn(),
     branchExists: jest.fn(),
     branchList: jest.fn(),
+    sparseCheckout: jest.fn(),
     checkout: jest.fn(),
     checkoutDetach: jest.fn(),
     config: jest.fn(
@@ -800,6 +801,7 @@ async function setup(testName: string): Promise<void> {
     authToken: 'some auth token',
     clean: true,
     commit: '',
+    sparseCheckout: [],
     fetchDepth: 1,
     lfs: false,
     submodules: false,

--- a/__test__/git-directory-helper.test.ts
+++ b/__test__/git-directory-helper.test.ts
@@ -462,6 +462,7 @@ async function setup(testName: string): Promise<void> {
     branchList: jest.fn(async () => {
       return []
     }),
+    sparseCheckout: jest.fn(),
     checkout: jest.fn(),
     checkoutDetach: jest.fn(),
     config: jest.fn(),

--- a/__test__/input-helper.test.ts
+++ b/__test__/input-helper.test.ts
@@ -79,6 +79,7 @@ describe('input-helper tests', () => {
     expect(settings.clean).toBe(true)
     expect(settings.commit).toBeTruthy()
     expect(settings.commit).toBe('1234567890123456789012345678901234567890')
+    expect(settings.sparseCheckout).toBe(undefined)
     expect(settings.fetchDepth).toBe(1)
     expect(settings.lfs).toBe(false)
     expect(settings.ref).toBe('refs/heads/some-ref')

--- a/__test__/verify-sparse-checkout-basic.sh
+++ b/__test__/verify-sparse-checkout-basic.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Verify .git folder
+if [ ! -d "./sparse-checkout/.git" ]; then
+  echo "Expected ./sparse-checkout/.git folder to exist"
+  exit 1
+fi
+
+# Verify sparse-checkout basic
+cd sparse-checkout
+
 SPARSE=$(git sparse-checkout list)
 
 if [ "$?" != "0" ]; then

--- a/__test__/verify-sparse-checkout-basic.sh
+++ b/__test__/verify-sparse-checkout-basic.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+SPARSE=$(git sparse-checkout list)
+
+if [ "$?" != "0" ]; then
+    echo "Failed to validate sparse-checkout"
+    exit 1
+fi
+
+# Check that sparse-checkout list is not empty
+if [ -z "$SPARSE" ]; then
+  echo "Expected sparse-checkout list to not be empty"
+  exit 1
+fi
+
+# Check that all folders from sparse-checkout exists
+for pattern in $(git sparse-checkout list)
+do
+  if [ ! -d "$pattern" ]; then
+    echo "Expected directory '$pattern' to exist"
+    exit 1
+  fi
+done

--- a/__test__/verify-sparse-checkout.sh
+++ b/__test__/verify-sparse-checkout.sh
@@ -1,5 +1,34 @@
 #!/bin/bash
 
+# Verify .git folder
+if [ ! -d "./sparse-checkout/.git" ]; then
+  echo "Expected ./sparse-checkout/.git folder to exist"
+  exit 1
+fi
+
+# Verify sparse-checkout
+cd sparse-checkout
+
+checkSparse () {
+  if [ ! -d "./$1" ]; then
+    echo "Expected directory '$1' to exist"
+    exit 1
+  fi
+
+  for file in $(git ls-tree -r --name-only HEAD $1)
+  do
+    if [ ! -f "$file" ]; then
+      echo "Expected file '$file' to exist"
+      exit 1
+    fi
+  done
+}
+
+# Check that all folders and its childrens has been fetched correctly
+checkSparse __test__
+checkSparse .github
+checkSparse dist
+
 # Check that only sparse-checkout folders has been fetched
 for pattern in $(git ls-tree --name-only HEAD)
 do
@@ -8,47 +37,5 @@ do
       echo "Expected directory '$pattern' to not exist"
       exit 1
     fi
-  fi
-done
-
-# Check that .github and its childrens has been fetched correctly
-if [ ! -d "./__test__" ]; then
-  echo "Expected directory '__test__' to exist"
-  exit 1
-fi
-
-for file in $(git ls-tree -r --name-only HEAD __test__)
-do
-  if [ ! -f "$file" ]; then
-    echo "Expected file '$file' to exist"
-    exit 1
-  fi
-done
-
-# Check that .github and its childrens has been fetched correctly
-if [ ! -d "./.github" ]; then
-  echo "Expected directory '.github' to exist"
-  exit 1
-fi
-
-for file in $(git ls-tree -r --name-only HEAD .github)
-do
-  if [ ! -f "$file" ]; then
-    echo "Expected file '$file' to exist"
-    exit 1
-  fi
-done
-
-# Check that dist and its childrens has been fetched correctly
-if [ ! -d "./dist" ]; then
-  echo "Expected directory 'dist' to exist"
-  exit 1
-fi
-
-for file in $(git ls-tree -r --name-only HEAD dist)
-do
-  if [ ! -f "$file" ]; then
-    echo "Expected file '$file' to exist"
-    exit 1
   fi
 done

--- a/__test__/verify-sparse-checkout.sh
+++ b/__test__/verify-sparse-checkout.sh
@@ -4,10 +4,24 @@
 for pattern in $(git ls-tree --name-only HEAD)
 do
   if [ -d "$pattern" ]; then
-    if [[ "$pattern" != ".github" && "$pattern" != "src" ]]; then
+    if [[ "$pattern" != "__test__" && "$pattern" != ".github" && "$pattern" != "src" ]]; then
       echo "Expected directory '$pattern' to not exist"
       exit 1
     fi
+  fi
+done
+
+# Check that .github and its childrens has been fetched correctly
+if [ ! -d "./__test__" ]; then
+  echo "Expected directory '__test__' to exist"
+  exit 1
+fi
+
+for file in $(git ls-tree -r --name-only HEAD __test__)
+do
+  if [ ! -f "$file" ]; then
+    echo "Expected file '$file' to exist"
+    exit 1
   fi
 done
 

--- a/__test__/verify-sparse-checkout.sh
+++ b/__test__/verify-sparse-checkout.sh
@@ -4,7 +4,7 @@
 for pattern in $(git ls-tree --name-only HEAD)
 do
   if [ -d "$pattern" ]; then
-    if [[ "$pattern" != "__test__" && "$pattern" != ".github" && "$pattern" != "src" ]]; then
+    if [[ "$pattern" != "__test__" && "$pattern" != ".github" && "$pattern" != "dist" ]]; then
       echo "Expected directory '$pattern' to not exist"
       exit 1
     fi
@@ -39,13 +39,13 @@ do
   fi
 done
 
-# Check that src and its childrens has been fetched correctly
-if [ ! -d "./src" ]; then
-  echo "Expected directory 'src' to exist"
+# Check that dist and its childrens has been fetched correctly
+if [ ! -d "./dist" ]; then
+  echo "Expected directory 'dist' to exist"
   exit 1
 fi
 
-for file in $(git ls-tree -r --name-only HEAD src)
+for file in $(git ls-tree -r --name-only HEAD dist)
 do
   if [ ! -f "$file" ]; then
     echo "Expected file '$file' to exist"

--- a/__test__/verify-sparse-checkout.sh
+++ b/__test__/verify-sparse-checkout.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Check that only sparse-checkout folders has been fetched
+for pattern in $(git ls-tree --name-only HEAD)
+do
+  if [ -d "$pattern" ]; then
+    if [[ "$pattern" != ".github" && "$pattern" != "src" ]]; then
+      echo "Expected directory '$pattern' to not exist"
+      exit 1
+    fi
+  fi
+done
+
+# Check that .github and its childrens has been fetched correctly
+if [ ! -d "./.github" ]; then
+  echo "Expected directory '.github' to exist"
+  exit 1
+fi
+
+for file in $(git ls-tree -r --name-only HEAD .github)
+do
+  if [ ! -f "$file" ]; then
+    echo "Expected file '$file' to exist"
+    exit 1
+  fi
+done
+
+# Check that src and its childrens has been fetched correctly
+if [ ! -d "./src" ]; then
+  echo "Expected directory 'src' to exist"
+  exit 1
+fi
+
+for file in $(git ls-tree -r --name-only HEAD src)
+do
+  if [ ! -f "$file" ]; then
+    echo "Expected file '$file' to exist"
+    exit 1
+  fi
+done

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,9 @@ inputs:
   clean:
     description: 'Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching'
     default: true
+  sparse-checkout:
+    description: 'Do a sparse checkout on given patterns'
+    default: null
   fetch-depth:
     description: 'Number of commits to fetch. 0 indicates all history for all branches and tags.'
     default: 1

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,9 @@ inputs:
     description: 'Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching'
     default: true
   sparse-checkout:
-    description: 'Do a sparse checkout on given patterns'
+    description: >
+      Do a sparse checkout on given patterns.
+      Each pattern should be sepparated with new lines
     default: null
   fetch-depth:
     description: 'Number of commits to fetch. 0 indicates all history for all branches and tags.'

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -16,6 +16,7 @@ export interface IGitCommandManager {
   branchDelete(remote: boolean, branch: string): Promise<void>
   branchExists(remote: boolean, pattern: string): Promise<boolean>
   branchList(remote: boolean): Promise<string[]>
+  sparseCheckout(sparseCheckout: string[]): Promise<void>
   checkout(ref: string, startPoint: string): Promise<void>
   checkoutDetach(): Promise<void>
   config(
@@ -25,7 +26,13 @@ export interface IGitCommandManager {
     add?: boolean
   ): Promise<void>
   configExists(configKey: string, globalConfig?: boolean): Promise<boolean>
-  fetch(refSpec: string[], fetchDepth?: number): Promise<void>
+  fetch(
+    refSpec: string[],
+    options: {
+      filter?: string
+      fetchDepth?: number
+    }
+  ): Promise<void>
   getDefaultBranch(repositoryUrl: string): Promise<string>
   getWorkingDirectory(): string
   init(): Promise<void>
@@ -154,6 +161,10 @@ class GitCommandManager {
     return result
   }
 
+  async sparseCheckout(sparseCheckout: string[]): Promise<void> {
+    await this.execGit(['sparse-checkout', 'set', ...sparseCheckout])
+  }
+
   async checkout(ref: string, startPoint: string): Promise<void> {
     const args = ['checkout', '--progress', '--force']
     if (startPoint) {
@@ -202,15 +213,23 @@ class GitCommandManager {
     return output.exitCode === 0
   }
 
-  async fetch(refSpec: string[], fetchDepth?: number): Promise<void> {
+  async fetch(
+    refSpec: string[],
+    options: {filter?: string; fetchDepth?: number}
+  ): Promise<void> {
     const args = ['-c', 'protocol.version=2', 'fetch']
     if (!refSpec.some(x => x === refHelper.tagsRefSpec)) {
       args.push('--no-tags')
     }
 
     args.push('--prune', '--progress', '--no-recurse-submodules')
-    if (fetchDepth && fetchDepth > 0) {
-      args.push(`--depth=${fetchDepth}`)
+
+    if (options.filter) {
+      args.push(`--filter=${options.filter}`)
+    }
+
+    if (options.fetchDepth && options.fetchDepth > 0) {
+      args.push(`--depth=${options.fetchDepth}`)
     } else if (
       fshelper.fileExistsSync(
         path.join(this.workingDirectory, '.git', 'shallow')
@@ -289,8 +308,8 @@ class GitCommandManager {
   }
 
   async log1(format?: string): Promise<string> {
-    var args = format ? ['log', '-1', format] : ['log', '-1']
-    var silent = format ? false : true
+    const args = format ? ['log', '-1', format] : ['log', '-1']
+    const silent = format ? false : true
     const output = await this.execGit(args, false, silent)
     return output.stdout
   }

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -30,6 +30,11 @@ export interface IGitSourceSettings {
   clean: boolean
 
   /**
+   * The array of folders to make the sparse checkout
+   */
+  sparseCheckout: string[]
+
+  /**
    * The depth when fetching
    */
   fetchDepth: number

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -82,6 +82,13 @@ export async function getInputs(): Promise<IGitSourceSettings> {
   result.clean = (core.getInput('clean') || 'true').toUpperCase() === 'TRUE'
   core.debug(`clean = ${result.clean}`)
 
+  // Sparse checkout
+  const sparseCheckout = core.getMultilineInput('sparse-checkout')
+  if (sparseCheckout.length) {
+    result.sparseCheckout = sparseCheckout
+    core.debug(`sparse checkout = ${result.sparseCheckout}`)
+  }
+
   // Fetch depth
   result.fetchDepth = Math.floor(Number(core.getInput('fetch-depth') || '1'))
   if (isNaN(result.fetchDepth) || result.fetchDepth < 0) {


### PR DESCRIPTION
# Context:
Monorepo sometimes can be challenging mainly when having a huge base of code. A lot of people have encounter situation where they don't need to fetch everything inside the repository, with this new option anyone will be able to make `sparse-checkout` inside github action quite simple!

# Features:
- Added `sparse-checkout` option
- Added test for `sparse-checkout`
- Updated `README.md` with `sparse-checkout` option and examples

# Usage:

## Fetch only the root files
```yaml
- uses: actions/checkout@v3
  with:
    sparse-checkout: .
```

## Fetch only the root files and `.github` and `src` folder

```yaml
- uses: actions/checkout@v3
  with:
    sparse-checkout: |
      .github
      src
```

> Once the first `sparse-checkout` is made you can download more folders with the [command](https://git-scm.com/docs/git-sparse-checkout#Documentation/git-sparse-checkout.txt-codegitsparse-checkoutaddSOMEDIRECTORYcode) `git sparse-checkout add SOME/DIR/ECTORY` more details rewarding `sparse-checkout` [here](https://git-scm.com/docs/git-sparse-checkout)


# Implementation

In order to make `sparase-checkout` much useful I have added to the `git fetch` the possibility to add a filter in order to use `--filter='blob:none'`.

With this update we will make sure that when the fetch is done no blob of the repository will be downloaded (this filter will be done only when `sparse-checkout` is set), instead the blobs will be downloaded when making the `git checkout` after having the `sparse-checkout` configured.

[Here](https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/) you can find the article that I have used to guide me to make the implementation.

# Related Issues
- https://github.com/actions/checkout/issues/800
- https://github.com/actions/checkout/pull/680