### PR TITLE
Mark test scripts with Bash'isms to be run via Bash

### DIFF
--- a/__test__/verify-sparse-checkout-non-cone-mode.sh
+++ b/__test__/verify-sparse-checkout-non-cone-mode.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Verify .git folder
 if [ ! -d "./sparse-checkout-non-cone-mode/.git" ]; then

--- a/__test__/verify-sparse-checkout.sh
+++ b/__test__/verify-sparse-checkout.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Verify .git folder
 if [ ! -d "./sparse-checkout/.git" ]; then


### PR DESCRIPTION
In #1369, I mistakenly replaced the hash-bang lines in the two new scripts with `#!/bin/sh`, missing that both files contain the Bash'ism `[[`. Symptom as per
https://github.com/actions/checkout/actions/runs/5200323109/jobs/9378889172?pr=1369#step:12:5

    __test__/verify-sparse-checkout.sh: 58: [[: not found

Let's change those hash-bang lines back to `#!/bin/bash`.