### PR TITLE
fix: anchors in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
     repository: my-org/my-tools
     path: my-tools
 ```
-> - If your secondary repository is private you will need to add the option noted in [Checkout multiple repos (private)](#Checkout-multiple-repos-private)
+> - If your secondary repository is private you will need to add the option noted in [Checkout multiple repos (private)](#checkout-multiple-repos-private)
 
 ## Checkout multiple repos (nested)
 
@@ -209,7 +209,7 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
     repository: my-org/my-tools
     path: my-tools
 ```
-> - If your secondary repository is private you will need to add the option noted in [Checkout multiple repos (private)](#Checkout-multiple-repos-private)
+> - If your secondary repository is private you will need to add the option noted in [Checkout multiple repos (private)](#checkout-multiple-repos-private)
 
 ## Checkout multiple repos (private)
 


### PR DESCRIPTION
Fixes the "Checkout multiple repos (private)" anchors in the README

They were previously not doing anything, now when you click on it it directs you to the right location

- https://github.com/actions/checkout#Checkout-multiple-repos-private (brings you nowhere)
- https://github.com/actions/checkout#checkout-multiple-repos-private (fixed)

You can view the rendered view of the README on my fork: https://github.com/Zarthus/checkout/tree/fix/readme-anchors
