### PR TITLE
Pass showProgress to fetchOptions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1243,7 +1243,9 @@ function getSource(settings) {
             }
             // Fetch
             core.startGroup('Fetching the repository');
-            const fetchOptions = {};
+            const fetchOptions = {
+                showProgress: settings.showProgress
+            };
             if (settings.filter) {
                 fetchOptions.filter = settings.filter;
             }

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -34,7 +34,7 @@ export interface IGitCommandManager {
       filter?: string
       fetchDepth?: number
       fetchTags?: boolean
-      showProgress?: boolean
+      showProgress: boolean
     }
   ): Promise<void>
   getDefaultBranch(repositoryUrl: string): Promise<string>
@@ -246,7 +246,7 @@ class GitCommandManager {
       filter?: string
       fetchDepth?: number
       fetchTags?: boolean
-      showProgress?: boolean
+      showProgress: boolean
     }
   ): Promise<void> {
     const args = ['-c', 'protocol.version=2', 'fetch']

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -157,8 +157,10 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
       filter?: string
       fetchDepth?: number
       fetchTags?: boolean
-      showProgress?: boolean
-    } = {}
+      showProgress: boolean
+    } = {
+      showProgress: settings.showProgress
+    }
 
     if (settings.filter) {
       fetchOptions.filter = settings.filter


### PR DESCRIPTION
Fix: #1453

#1067 seems not to pass `showProgress` to fetchOptions, which makes any fetch call handled without `--progress`
Confirmed works correctly with default / explicitly given show-progress option, here is test result
https://github.com/riseshia/actions-playground/actions/runs/6078541181

I don't add test for this, because I couldn't find proper place for this case(most test are unit testing, but this problem is from "passing" arg) 🤔 
any suggestion for adding test is welcome. ;)