### PR TITLE
Add ssh fetch with custome port

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2371,14 +2371,16 @@ function getFetchUrl(settings) {
     const encodedOwner = encodeURIComponent(settings.repositoryOwner);
     const encodedName = encodeURIComponent(settings.repositoryName);
     if (settings.sshKey) {
-        return `git@${serviceUrl.hostname}:${encodedOwner}/${encodedName}.git`;
+        return serviceUrl.port === ''
+            ? `git@${serviceUrl.hostname}:${encodedOwner}/${encodedName}.git`
+            : `ssh://git@${serviceUrl.hostname}:${serviceUrl.port}/${encodedOwner}/${encodedName}.git`;
     }
     // "origin" is SCHEME://HOSTNAME[:PORT]
     return `${serviceUrl.origin}/${encodedOwner}/${encodedName}`;
 }
 exports.getFetchUrl = getFetchUrl;
 function getServerUrl(url) {
-    let urlValue = url && url.trim().length > 0
+    const urlValue = url && url.trim().length > 0
         ? url
         : process.env['GITHUB_SERVER_URL'] || 'https://github.com';
     return new url_1.URL(urlValue);

--- a/src/url-helper.ts
+++ b/src/url-helper.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
-import {URL} from 'url'
 import {IGitSourceSettings} from './git-source-settings'
+import {URL} from 'url'
 
 export function getFetchUrl(settings: IGitSourceSettings): string {
   assert.ok(
@@ -11,8 +11,11 @@ export function getFetchUrl(settings: IGitSourceSettings): string {
   const serviceUrl = getServerUrl(settings.githubServerUrl)
   const encodedOwner = encodeURIComponent(settings.repositoryOwner)
   const encodedName = encodeURIComponent(settings.repositoryName)
+
   if (settings.sshKey) {
-    return `git@${serviceUrl.hostname}:${encodedOwner}/${encodedName}.git`
+    return serviceUrl.port === ''
+      ? `git@${serviceUrl.hostname}:${encodedOwner}/${encodedName}.git`
+      : `ssh://git@${serviceUrl.hostname}:${serviceUrl.port}/${encodedOwner}/${encodedName}.git`
   }
 
   // "origin" is SCHEME://HOSTNAME[:PORT]
@@ -20,7 +23,7 @@ export function getFetchUrl(settings: IGitSourceSettings): string {
 }
 
 export function getServerUrl(url?: string): URL {
-  let urlValue =
+  const urlValue =
     url && url.trim().length > 0
       ? url
       : process.env['GITHUB_SERVER_URL'] || 'https://github.com'


### PR DESCRIPTION
This adds support for costume ssh ports. If `github-server-url` has a url with a different ssh port like (`https://example.com:222`) and fetching with ssh is selected, this commit adds the required `ssh://` and the port to the origin url. 

Tested with costume ssh port (`https://example.com:222`), no ssh port (`https://example.com`) where default port `22` is used and with default port `22` explicitly set (`https://example.com:22`).

closes #1315