### PR TITLE
Add support to customize working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Please refer to the [release page](https://github.com/actions/checkout/releases/
     # Default: true
     persist-credentials: ''
 
-    # Relative path under $GITHUB_WORKSPACE to place the repository
+    # Relative path under $GITHUB_WORKSPACE/working-directory to place the repository
     path: ''
 
     # Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching
@@ -126,6 +126,10 @@ Please refer to the [release page](https://github.com/actions/checkout/releases/
     # running from unless specified. Example URLs are https://github.com or
     # https://my-ghes-server.example.com
     github-server-url: ''
+
+    # Provide the working directory for the git commands to execute into, defaults to
+    # $GITHUB_WORKSPACE
+    working-directory: ''
 ```
 <!-- end usage -->
 

--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -825,7 +825,6 @@ async function setup(testName: string): Promise<void> {
     workflowOrganizationId: 123456,
     setSafeDirectory: true,
     githubServerUrl: githubServerUrl,
-    workingDirectory: undefined
   }
 }
 

--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -824,7 +824,8 @@ async function setup(testName: string): Promise<void> {
     sshUser: '',
     workflowOrganizationId: 123456,
     setSafeDirectory: true,
-    githubServerUrl: githubServerUrl
+    githubServerUrl: githubServerUrl,
+    workingDirectory: undefined
   }
 }
 

--- a/__test__/input-helper.test.ts
+++ b/__test__/input-helper.test.ts
@@ -144,4 +144,25 @@ describe('input-helper tests', () => {
     const settings: IGitSourceSettings = await inputHelper.getInputs()
     expect(settings.workflowOrganizationId).toBe(123456)
   })
+
+  it('sets a different working directory', async() => {
+    inputs['working-directory'] = '/home/user/test'
+    inputs['path'] = 'path/to/repo'
+    const settings: IGitSourceSettings = await inputHelper.getInputs()
+    expect(settings.repositoryPath).toBe(path.resolve('/home/user/test/path/to/repo'))
+  })
+
+  it('sets a working directory on root', async() => {
+    inputs['working-directory'] = '/'
+    inputs['path'] = 'path/to/repo'
+    const settings: IGitSourceSettings = await inputHelper.getInputs()
+    expect(settings.repositoryPath).toBe(path.resolve('/path/to/repo'))
+  })
+
+  it('sets a working directory on root and repository path is set to empty', async() => {
+    inputs['working-directory'] = '/'
+    inputs['path'] = ''
+    const settings: IGitSourceSettings = await inputHelper.getInputs()
+    expect(settings.repositoryPath).toBe(path.resolve('/'))
+  })
 })

--- a/action.yml
+++ b/action.yml
@@ -98,6 +98,9 @@ inputs:
   github-server-url:
     description: The base URL for the GitHub instance that you are trying to clone from, will use environment defaults to fetch from the same instance that the workflow is running from unless specified. Example URLs are https://github.com or https://my-ghes-server.example.com
     required: false
+  working-directory:
+    description: Provide the working directory for the git commands to execute into, defaults to $GITHUB_WORKSPACE
+    required: false
 runs:
   using: node20
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ inputs:
     description: 'Whether to configure the token or SSH key with the local git config'
     default: true
   path:
-    description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
+    description: 'Relative path under $GITHUB_WORKSPACE/working-directory to place the repository'
   clean:
     description: 'Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching'
     default: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -1716,14 +1716,14 @@ const workflowContextHelper = __importStar(__nccwpck_require__(9568));
 function getInputs() {
     return __awaiter(this, void 0, void 0, function* () {
         const result = {};
-        // GitHub workspace
-        let githubWorkspacePath = process.env['GITHUB_WORKSPACE'];
-        if (!githubWorkspacePath) {
-            throw new Error('GITHUB_WORKSPACE not defined');
+        // Working directory
+        let workingDirectory = core.getInput('workingDirectory') || process.env['GITHUB_WORKSPACE'];
+        if (!workingDirectory) {
+            throw new Error('working dir not defined');
         }
-        githubWorkspacePath = path.resolve(githubWorkspacePath);
-        core.debug(`GITHUB_WORKSPACE = '${githubWorkspacePath}'`);
-        fsHelper.directoryExistsSync(githubWorkspacePath, true);
+        workingDirectory = path.resolve(workingDirectory);
+        core.debug(`working directory = '${workingDirectory}'`);
+        fsHelper.directoryExistsSync(workingDirectory, true);
         // Qualified repository
         const qualifiedRepository = core.getInput('repository') ||
             `${github.context.repo.owner}/${github.context.repo.repo}`;
@@ -1738,9 +1738,9 @@ function getInputs() {
         result.repositoryName = splitRepository[1];
         // Repository path
         result.repositoryPath = core.getInput('path') || '.';
-        result.repositoryPath = path.resolve(githubWorkspacePath, result.repositoryPath);
-        if (!(result.repositoryPath + path.sep).startsWith(githubWorkspacePath + path.sep)) {
-            throw new Error(`Repository path '${result.repositoryPath}' is not under '${githubWorkspacePath}'`);
+        result.repositoryPath = path.resolve(workingDirectory, result.repositoryPath);
+        if (!(result.repositoryPath + path.sep).startsWith(workingDirectory + path.sep)) {
+            throw new Error(`Repository path '${result.repositoryPath}' is not under '${workingDirectory}'`);
         }
         // Workflow repository?
         const isWorkflowRepository = qualifiedRepository.toUpperCase() ===

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -118,4 +118,9 @@ export interface IGitSourceSettings {
    * User override on the GitHub Server/Host URL that hosts the repository to be cloned
    */
   githubServerUrl: string | undefined
+
+  /**
+   * User override of the working directory (default is $GITHUB_WORKSPACE)
+   */
+  workingDirectory: string | undefined
 }

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -118,9 +118,4 @@ export interface IGitSourceSettings {
    * User override on the GitHub Server/Host URL that hosts the repository to be cloned
    */
   githubServerUrl: string | undefined
-
-  /**
-   * User override of the working directory (default is $GITHUB_WORKSPACE)
-   */
-  workingDirectory: string | undefined
 }

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -9,7 +9,7 @@ export async function getInputs(): Promise<IGitSourceSettings> {
   const result = {} as unknown as IGitSourceSettings
 
   // Working directory
-  let workingDirectory = core.getInput('workingDirectory') || process.env['GITHUB_WORKSPACE']
+  let workingDirectory = core.getInput('working-directory') || process.env['GITHUB_WORKSPACE']
   if (!workingDirectory) {
     throw new Error('working dir not defined')
   }

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -43,11 +43,11 @@ export async function getInputs(): Promise<IGitSourceSettings> {
   )
   if (
     !(result.repositoryPath + path.sep).startsWith(
-      workingDirectory + path.sep
+      workingDirectory
     )
   ) {
     throw new Error(
-      `Repository path '${result.repositoryPath}' is not under '${workingDirectory}'`
+      `Repository path '${result.repositoryPath + path.sep}' is not under '${workingDirectory}'`
     )
   }
 

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -8,14 +8,14 @@ import {IGitSourceSettings} from './git-source-settings'
 export async function getInputs(): Promise<IGitSourceSettings> {
   const result = {} as unknown as IGitSourceSettings
 
-  // GitHub workspace
-  let githubWorkspacePath = process.env['GITHUB_WORKSPACE']
-  if (!githubWorkspacePath) {
-    throw new Error('GITHUB_WORKSPACE not defined')
+  // Working directory
+  let workingDirectory = core.getInput('workingDirectory') || process.env['GITHUB_WORKSPACE']
+  if (!workingDirectory) {
+    throw new Error('working dir not defined')
   }
-  githubWorkspacePath = path.resolve(githubWorkspacePath)
-  core.debug(`GITHUB_WORKSPACE = '${githubWorkspacePath}'`)
-  fsHelper.directoryExistsSync(githubWorkspacePath, true)
+  workingDirectory = path.resolve(workingDirectory)
+  core.debug(`working directory = '${workingDirectory}'`)
+  fsHelper.directoryExistsSync(workingDirectory, true)
 
   // Qualified repository
   const qualifiedRepository =
@@ -38,16 +38,16 @@ export async function getInputs(): Promise<IGitSourceSettings> {
   // Repository path
   result.repositoryPath = core.getInput('path') || '.'
   result.repositoryPath = path.resolve(
-    githubWorkspacePath,
+    workingDirectory,
     result.repositoryPath
   )
   if (
     !(result.repositoryPath + path.sep).startsWith(
-      githubWorkspacePath + path.sep
+      workingDirectory + path.sep
     )
   ) {
     throw new Error(
-      `Repository path '${result.repositoryPath}' is not under '${githubWorkspacePath}'`
+      `Repository path '${result.repositoryPath}' is not under '${workingDirectory}'`
     )
   }
 


### PR DESCRIPTION
Allow the users to customize the working directory where the commands of the action will be executed, e.g.: c:\, /home/user, etc.
This is to allow the users to switch to a different mount point (for example github hosted windows runners offer quite a bit of space but the checkout process happens on d:\, where the space is only 14GB).
Sometimes it is not feasible to copy the repository after cloning it because:
- It might be too big, costing a lot of time and thus increasing the billing
- It might have constraints (symbolic links) that make it impossible to copy
I have added a few unit tests and tested it on a windows-latest runner on this repository: 
https://github.com/accodev/trackmania-manager-py/actions/runs/6263454133/job/17007891987
Note that the chosen working directory has to exists (kept the original behaviour).