### PR TITLE
Fix cases where there is a "HEAD" file or folder at the root 

### DIFF
--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -471,7 +471,7 @@ class GitCommandManager {
   }
 
   async tryReset(): Promise<boolean> {
-    const output = await this.execGit(['reset', '--hard', 'HEAD'], true)
+    const output = await this.execGit(['reset', '--hard', 'HEAD', '--'], true)
     return output.exitCode === 0
   }
 


### PR DESCRIPTION
of the repo (or, for Windows, Head, head, etc) by making sure HEAD is not treated as a filename