### PR TITLE
Document that filter doesn't override fetch-depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
     clean: ''
 
     # Partially clone against a given filter. Overrides sparse-checkout if set.
+    # Note that when a filter is provided, fetch-depth is still respected; you
+    # may want to specify `fetch-depth: 0` to ensure the full history is fetched.
     # Default: null
     filter: ''
 

--- a/action.yml
+++ b/action.yml
@@ -55,8 +55,9 @@ inputs:
     default: true
   filter:
     description: >
-      Partially clone against a given filter.
-      Overrides sparse-checkout if set.
+      Partially clone against a given filter. Overrides sparse-checkout if set.
+      Note that when a filter is provided, fetch-depth is still respected; you
+      may want to specify `fetch-depth: 0` to ensure the full history is fetched.
     default: null
   sparse-checkout:
     description: >


### PR DESCRIPTION
As noted in https://github.com/actions/checkout/pull/1396#issuecomment-1741638179, if you want to make full use of `filter: blob:none`, you still need to set `fetch-depth: 0`, as the default is still `1` which means you still don't get any history.

Happy to change this to whatever makes sense.