### PR TITLE
Fix checkout of annotated tag loosing annotation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2059,7 +2059,8 @@ function testRef(git, ref, commit) {
         // refs/tags/
         else if (upperRef.startsWith('REFS/TAGS/')) {
             const tagName = ref.substring('refs/tags/'.length);
-            return ((yield git.tagExists(tagName)) && commit === (yield git.revParse(ref)));
+            return ((yield git.tagExists(tagName)) &&
+                commit === (yield git.revParse(`${ref}^{commit}`)));
         }
         // Unexpected
         else {

--- a/src/ref-helper.ts
+++ b/src/ref-helper.ts
@@ -167,7 +167,8 @@ export async function testRef(
   else if (upperRef.startsWith('REFS/TAGS/')) {
     const tagName = ref.substring('refs/tags/'.length)
     return (
-      (await git.tagExists(tagName)) && commit === (await git.revParse(ref))
+      (await git.tagExists(tagName)) &&
+      commit === (await git.revParse(`${ref}^{commit}`))
     )
   }
   // Unexpected


### PR DESCRIPTION
Currently, a check is done after fetch to ensure that the repo state has not changed since the workflow was triggered. This check will reset the checkout to the commit that triggered the workflow, even if the branch or tag has moved since.

The issue is that the check currently sees what "object" the ref points to. For an annotated tag, that is the annotation, not the commit. This means the check always fails for annotated tags, and they are reset to the commit, losing the annotation. Losing the annotation can be fatal, as `git describe` will only match annotated tags.

The fix is simple: check if the tag points at the right commit, ignoring any other type of object. This is done with the `<rev>^{commit}` syntax.

From the git-rev-parse docs:
> \<rev>^{<type>}, e.g. v0.99.8^{commit}
>    A suffix ^ followed by an object type name enclosed in brace pair means dereference the object at \<rev> recursively until an object of type \<type> is found or the object cannot be dereferenced anymore (in which case, barf). For example, if \<rev> is a commit-ish, \<rev>^{commit} describes the corresponding commit object. Similarly, if \<rev> is a tree-ish, \<rev>^{tree} describes the corresponding tree object.  \<rev>^0 is a short-hand for \<rev>^{commit}.

If the check still fails, we will still reset the tag to the commit, losing the annotation. However, there is no way to truly recover in this situtation, as GitHub does not capture the annotation on workflow start, and since the history has changed, we can not trust the new tag to contain the same data as it did before.

Fixes #290
Closes #697

(I marked this as closing #697 since this fixes the same issue. This fix is better (in my opinion), as this is less of a deviation from the current functionality.)