### PR TITLE
support pathname in githubServerUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
 
     # The base URL for the GitHub instance that you are trying to clone from, will use
     # environment defaults to fetch from the same instance that the workflow is
-    # running from unless specified. Example URLs are https://github.com or
-    # https://my-ghes-server.example.com
+    # running from unless specified. Also support URL pathname except SSH (`ssh-key`
+    # not specified). Example URLs are https://github.com or
+    # https://my-ghes-server.example.com or https://my-ghes-server.example.com/git/
     github-server-url: ''
 ```
 <!-- end usage -->

--- a/__test__/url-helper.test.ts
+++ b/__test__/url-helper.test.ts
@@ -1,0 +1,46 @@
+import * as urlHelper from '../lib/url-helper'
+
+import { IGitSourceSettings } from '../lib/git-source-settings';
+
+function getSettings(u: string): IGitSourceSettings {
+  return {
+    githubServerUrl: u,
+    repositoryPath: '',
+    repositoryOwner: 'some-owner',
+    repositoryName: 'some-name',
+    ref: '', commit: '', clean: false, filter: undefined,
+    sparseCheckout: [], sparseCheckoutConeMode: false,
+    fetchDepth: 0, fetchTags: false, showProgress: false,
+    lfs: false, submodules: false, nestedSubmodules: false,
+    authToken: '', sshKey: '', sshKnownHosts: '', sshStrict: false,
+    persistCredentials: false, workflowOrganizationId: undefined,
+    setSafeDirectory: false
+  }
+}
+describe('url-helper tests', () => {
+  it('getFetchUrl works on GitHub repos', async () => {
+    expect(urlHelper.getFetchUrl(getSettings('https://github.com'))).toBe(
+      "https://github.com/some-owner/some-name"
+    )
+  })
+
+  it('getFetchUrl works on 3rd party repos with sub-path', async () => {
+    expect(urlHelper.getFetchUrl(getSettings('https://other.com/subpath'))).toBe(
+      'https://other.com/subpath/some-owner/some-name'
+    )
+  })
+
+  it('getFetchUrl works on 3rd party repos with ssh keys', async () => {
+    expect(urlHelper.getFetchUrl(getSettings('https://other.com/subpath'))).toBe(
+      'https://other.com/subpath/some-owner/some-name'
+    )
+  })
+
+  it('getFetchUrl works with ssh credentials', async () => {
+    let settings = getSettings('https://other.com/subpath');
+    settings.sshKey = 'not-empty'
+    expect(urlHelper.getFetchUrl(settings)).toBe(
+      'git@other.com:some-owner/some-name.git'
+    )
+  })
+})

--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,7 @@ inputs:
     description: Add repository path as safe.directory for Git global config by running `git config --global --add safe.directory <path>`
     default: true
   github-server-url:
-    description: The base URL for the GitHub instance that you are trying to clone from, will use environment defaults to fetch from the same instance that the workflow is running from unless specified. Example URLs are https://github.com or https://my-ghes-server.example.com
+    description: The base URL for the GitHub instance that you are trying to clone from, will use environment defaults to fetch from the same instance that the workflow is running from unless specified. Also support URL pathname except SSH (`ssh-key` not specified). Example URLs are https://github.com or https://my-ghes-server.example.com or https://my-ghes-server.example.com/git/
     required: false
 runs:
   using: node20

--- a/dist/index.js
+++ b/dist/index.js
@@ -163,13 +163,14 @@ class GitAuthHelper {
         this.settings = gitSourceSettings || {};
         // Token auth header
         const serverUrl = urlHelper.getServerUrl(this.settings.githubServerUrl);
-        this.tokenConfigKey = `http.${serverUrl.origin}/.extraheader`; // "origin" is SCHEME://HOSTNAME[:PORT]
+        const baseURL = urlHelper.getBaseUrl(serverUrl.href);
+        this.tokenConfigKey = `http.${baseURL}/.extraheader`; // "origin" is SCHEME://HOSTNAME[:PORT]
         const basicCredential = Buffer.from(`x-access-token:${this.settings.authToken}`, 'utf8').toString('base64');
         core.setSecret(basicCredential);
         this.tokenPlaceholderConfigValue = `AUTHORIZATION: basic ***`;
         this.tokenConfigValue = `AUTHORIZATION: basic ${basicCredential}`;
         // Instead of SSH URL
-        this.insteadOfKey = `url.${serverUrl.origin}/.insteadOf`; // "origin" is SCHEME://HOSTNAME[:PORT]
+        this.insteadOfKey = `url.${baseURL}/.insteadOf`; // "origin" is SCHEME://HOSTNAME[:PORT]
         this.insteadOfValues.push(`git@${serverUrl.hostname}:`);
         if (this.settings.workflowOrganizationId) {
             this.insteadOfValues.push(`org-${this.settings.workflowOrganizationId}@github.com:`);
@@ -2371,7 +2372,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.isGhes = exports.getServerApiUrl = exports.getServerUrl = exports.getFetchUrl = void 0;
+exports.isGhes = exports.getServerApiUrl = exports.getBaseUrl = exports.getServerUrl = exports.getFetchUrl = void 0;
 const assert = __importStar(__nccwpck_require__(9491));
 const url_1 = __nccwpck_require__(7310);
 function getFetchUrl(settings) {
@@ -2384,16 +2385,22 @@ function getFetchUrl(settings) {
         return `git@${serviceUrl.hostname}:${encodedOwner}/${encodedName}.git`;
     }
     // "origin" is SCHEME://HOSTNAME[:PORT]
-    return `${serviceUrl.origin}/${encodedOwner}/${encodedName}`;
+    const baseURL = getBaseUrl(serviceUrl.href);
+    return `${baseURL}/${encodedOwner}/${encodedName}`;
 }
 exports.getFetchUrl = getFetchUrl;
 function getServerUrl(url) {
-    let urlValue = url && url.trim().length > 0
+    const urlValue = url && url.trim().length > 0
         ? url
         : process.env['GITHUB_SERVER_URL'] || 'https://github.com';
     return new url_1.URL(urlValue);
 }
 exports.getServerUrl = getServerUrl;
+function getBaseUrl(url) {
+    const matcher = url.match(/^[^?]+/);
+    return (matcher && matcher[0].replace(/\/+$/g, '')) || '';
+}
+exports.getBaseUrl = getBaseUrl;
 function getServerApiUrl(url) {
     let apiUrl = 'https://api.github.com';
     if (isGhes(url)) {

--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -53,7 +53,8 @@ class GitAuthHelper {
 
     // Token auth header
     const serverUrl = urlHelper.getServerUrl(this.settings.githubServerUrl)
-    this.tokenConfigKey = `http.${serverUrl.origin}/.extraheader` // "origin" is SCHEME://HOSTNAME[:PORT]
+    const baseURL = urlHelper.getBaseUrl(serverUrl.href)
+    this.tokenConfigKey = `http.${baseURL}/.extraheader` // "origin" is SCHEME://HOSTNAME[:PORT]
     const basicCredential = Buffer.from(
       `x-access-token:${this.settings.authToken}`,
       'utf8'
@@ -63,7 +64,7 @@ class GitAuthHelper {
     this.tokenConfigValue = `AUTHORIZATION: basic ${basicCredential}`
 
     // Instead of SSH URL
-    this.insteadOfKey = `url.${serverUrl.origin}/.insteadOf` // "origin" is SCHEME://HOSTNAME[:PORT]
+    this.insteadOfKey = `url.${baseURL}/.insteadOf` // "origin" is SCHEME://HOSTNAME[:PORT]
     this.insteadOfValues.push(`git@${serverUrl.hostname}:`)
     if (this.settings.workflowOrganizationId) {
       this.insteadOfValues.push(

--- a/src/url-helper.ts
+++ b/src/url-helper.ts
@@ -16,15 +16,21 @@ export function getFetchUrl(settings: IGitSourceSettings): string {
   }
 
   // "origin" is SCHEME://HOSTNAME[:PORT]
-  return `${serviceUrl.origin}/${encodedOwner}/${encodedName}`
+  const baseURL = getBaseUrl(serviceUrl.href)
+  return `${baseURL}/${encodedOwner}/${encodedName}`
 }
 
 export function getServerUrl(url?: string): URL {
-  let urlValue =
+  const urlValue =
     url && url.trim().length > 0
       ? url
       : process.env['GITHUB_SERVER_URL'] || 'https://github.com'
   return new URL(urlValue)
+}
+
+export function getBaseUrl(url: string): string {
+  const matcher = url.match(/^[^?]+/)
+  return (matcher && matcher[0].replace(/\/+$/g, '')) || ''
 }
 
 export function getServerApiUrl(url?: string): string {

--- a/src/url-helper.ts
+++ b/src/url-helper.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
-import {URL} from 'url'
-import {IGitSourceSettings} from './git-source-settings'
+import { URL } from 'url'
+import { IGitSourceSettings } from './git-source-settings'
 
 export function getFetchUrl(settings: IGitSourceSettings): string {
   assert.ok(
@@ -16,7 +16,7 @@ export function getFetchUrl(settings: IGitSourceSettings): string {
   }
 
   // "origin" is SCHEME://HOSTNAME[:PORT]
-  const baseURL = getBaseUrl(serviceUrl.href)
+  const baseURL = getBaseUrl(serviceUrl)
   return `${baseURL}/${encodedOwner}/${encodedName}`
 }
 
@@ -28,9 +28,8 @@ export function getServerUrl(url?: string): URL {
   return new URL(urlValue)
 }
 
-export function getBaseUrl(url: string): string {
-  const matcher = url.match(/^[^?]+/)
-  return (matcher && matcher[0].replace(/\/+$/g, '')) || ''
+function getBaseUrl(u: URL) {
+  return u.protocol + "//" + u.host + u.pathname.replace(/\/+$/g, '');
 }
 
 export function getServerApiUrl(url?: string): string {


### PR DESCRIPTION
make actions/checkout work on custom git servers that are deployed on subpaths.

this is continuation to https://github.com/actions/checkout/pull/1305 cc @megamanics 

closes https://github.com/actions/checkout/issues/1242