### PR TITLE
Give `test-ubuntu-git` its own `README`

### DIFF
--- a/images/test-ubuntu-git.Dockerfile
+++ b/images/test-ubuntu-git.Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:latest
 RUN apt update
 RUN apt install -y git
 
-LABEL org.opencontainers.image.title="Ubuntu with git"
-LABEL org.opencontainers.image.description="Ubuntu image with git pre-installed"
+LABEL org.opencontainers.image.title="Ubuntu + git (validation image)"
+LABEL org.opencontainers.image.description="Ubuntu image with git pre-installed.  Intended primarily for testing `actions/checkout` during CI/CD workflows."
 LABEL org.opencontainers.image.documentation="https://github.com/actions/checkout/tree/main/images/test-ubuntu-git.md"
 LABEL org.opencontainers.image.licenses=MIT

--- a/images/test-ubuntu-git.Dockerfile
+++ b/images/test-ubuntu-git.Dockerfile
@@ -7,6 +7,6 @@ RUN apt update
 RUN apt install -y git
 
 LABEL org.opencontainers.image.title="Ubuntu + git (validation image)"
-LABEL org.opencontainers.image.description="Ubuntu image with git pre-installed.  Intended primarily for testing `actions/checkout` during CI/CD workflows."
+LABEL org.opencontainers.image.description="Ubuntu image with git pre-installed. Intended primarily for testing `actions/checkout` during CI/CD workflows."
 LABEL org.opencontainers.image.documentation="https://github.com/actions/checkout/tree/main/images/test-ubuntu-git.md"
 LABEL org.opencontainers.image.licenses=MIT

--- a/images/test-ubuntu-git.Dockerfile
+++ b/images/test-ubuntu-git.Dockerfile
@@ -6,5 +6,7 @@ FROM ubuntu:latest
 RUN apt update
 RUN apt install -y git
 
+LABEL org.opencontainers.image.title="Ubuntu with git"
 LABEL org.opencontainers.image.description="Ubuntu image with git pre-installed"
+LABEL org.opencontainers.image.documentation="https://github.com/actions/checkout/tree/main/images/test-ubuntu-git.md"
 LABEL org.opencontainers.image.licenses=MIT

--- a/images/test-ubuntu-git.md
+++ b/images/test-ubuntu-git.md
@@ -1,0 +1,1 @@
+## TODO:  Details for `test-ubuntu-git`

--- a/images/test-ubuntu-git.md
+++ b/images/test-ubuntu-git.md
@@ -1,1 +1,15 @@
-## TODO:  Details for `test-ubuntu-git`
+# `test-ubuntu-git` Container Image
+
+[![Publish test-ubuntu-git Container](https://github.com/actions/checkout/actions/workflows/update-test-ubuntu-git.yml/badge.svg)](https://github.com/actions/checkout/actions/workflows/update-test-ubuntu-git.yml)
+
+## Purpose
+
+`test-ubuntu-git` is a container image hosted on the GitHub Container Registry, `ghcr.io`.  
+
+It is intended primarily for testing the [`actions/checkout` repository](https://github.com/actions/checkout) as part of `actions/checkout`'s CI/CD workflows.
+
+The composition of `test-ubuntu-git` is intentionally minimal.  It is comprised of [git](https://git-scm.com/) installed on top of a [base-level ubuntu image](https://hub.docker.com/_/ubuntu/tags).
+
+# License
+
+`test-ubuntu-git` is released under the [MIT License](/LICENSE).


### PR DESCRIPTION
By default, `test-ubuntu-git` is inheriting the `README.md` of `actions/checkout`.

![image](https://github.com/actions/checkout/assets/81404201/6a0d3af0-6ff2-497a-90ca-70d7e1310d73)



It should have a separate README.  This PR achieves that.