### PR TITLE
Warn on attempts to publish `test-ubuntu-git` from non-main branch.

### DIFF
--- a/.github/workflows/update-test-ubuntu-git.yml
+++ b/.github/workflows/update-test-ubuntu-git.yml
@@ -47,7 +47,7 @@ jobs:
         run: echo "::warning::test-ubuntu-git images can only be published from the actions/checkout 'main' branch.  Workflow will continue with push/publish disabled."
 
       # Use `docker/build-push-action` to build (and optionally publish) the image. 
-      - name: Build and push Docker image
+      - name: Build Docker Image (with optional Push)
         uses: docker/build-push-action@v5.1.0
         with:
           context: .

--- a/.github/workflows/update-test-ubuntu-git.yml
+++ b/.github/workflows/update-test-ubuntu-git.yml
@@ -42,6 +42,10 @@ jobs:
         # Use `date` with a custom format to achieve the key=value format GITHUB_OUTPUT expects.
         run: date -u "+now=%Y%m%d.%H%M%S.%3NZ" >> "$GITHUB_OUTPUT"
 
+      - name: Issue Image Publish Warning
+        if:  ${{ inputs.publish && github.ref_name != 'main' }}
+        run: echo "::warning::test-ubuntu-git images can only be published from the actions/checkout 'main' branch.  Workflow will continue with push/publish disabled."
+
       # Use `docker/build-push-action` to build (and optionally publish) the image. 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5.1.0


### PR DESCRIPTION
When we built the `test-ubuntu-git` image generation workflow, we made the decision to only allow the `test-ubuntu-git` container image to be published from the `main` branch of `actions/checkout`.  (see https://github.com/actions/checkout/pull/1617)

This PR updates the workflow to explain (via a warning message) why an image push attempt from a non-`main` branch didn't have the desired effect (for users that weren't paying close attention to the label of the checkbox which reads:  `"Publish to ghcr.io? (main branch only)"`).

Note that `push` is an opt-in behavior of reusable workflow `docker/build-push-action`. 
 There's diagnostic value in the build attempt that precedes any would-be image push, so I chose not to fail the workflow outright, but rather to let the build proceed and simply *skip* the push.