### PR TITLE
update action workflows to use checkout@v4

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set Node.js 20.x
         uses: actions/setup-node@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Check licenses
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: npm ci
       - run: npm run licensed-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
       - releases/*
 
 
-# Note that when you see patterns like "ref: test-data/v2/basic" within this workflow, 
+# Note that when you see patterns like "ref: test-data/v2/basic" within this workflow,
 # these refer to "test-data" branches on this actions/checkout repo.
 # (For example, test-data/v2/basic -> https://github.com/actions/checkout/tree/test-data/v2/basic)
 
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 20.x
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: npm ci
       - run: npm run build
       - run: npm run format-check
@@ -37,7 +37,7 @@ jobs:
     steps:
       # Clone this repo
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Basic checkout
       - name: Checkout basic
@@ -202,7 +202,7 @@ jobs:
     steps:
       # Clone this repo
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Basic checkout using git
       - name: Checkout basic
@@ -234,7 +234,7 @@ jobs:
     steps:
       # Clone this repo
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Basic checkout using git
       - name: Checkout basic
@@ -257,14 +257,14 @@ jobs:
           path: basic
       - name: Verify basic
         run: __test__/verify-basic.sh --archive
-    
+
   test-git-container:
     runs-on: ubuntu-latest
     container: bitnami/git:latest
     steps:
       # Clone this repo
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: v3
 
@@ -292,6 +292,6 @@ jobs:
 
       # needed to make checkout post cleanup succeed
       - name: Fix Checkout v3
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: v3

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -19,7 +19,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Git config


### PR DESCRIPTION
With the release of `actions/checkout@v4` almost six months ago in actions/checkout#1447, this PR updates the workflows in this repo to use the latest major version of `checkout`.