### PR TITLE
Added retry to submodule cloning

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -792,7 +792,10 @@ class GitCommandManager {
             if (recursive) {
                 args.push('--recursive');
             }
-            yield this.execGit(args);
+            const that = this;
+            yield retryHelper.execute(() => __awaiter(this, void 0, void 0, function* () {
+                yield that.execGit(args);
+            }));
         });
     }
     submoduleStatus() {

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -414,7 +414,10 @@ class GitCommandManager {
       args.push('--recursive')
     }
 
-    await this.execGit(args)
+    const that = this
+    await retryHelper.execute(async () => {
+      await that.execGit(args)
+    })
   }
 
   async submoduleStatus(): Promise<boolean> {


### PR DESCRIPTION
When using actions/checkout@v3 or v4 we experience intermittent failures on workflows cloning submodules. The failures result in following error: `unable to access <SUBMODULE REPO URL>: gnutls_handshake() failed: Error in the pull function.`

Our environment is primarily self hosted runners using the [action_controller_runner](https://github.com/actions/actions-runner-controller),

Re-running the workflows failed steps resolves the issues every time we've tried it. This PR adds the same retry logic that is used with the normal fetch flow used by the actions/checkout action. I have verified this change resolves the intermittent failures and passes the format-check, lint, and test steps described in the test.yml workflow.

