### PR TITLE
Prep for release of  v4.1.2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 - Fix: Disable sparse checkout whenever `sparse-checkout` option is not present @dscho in https://github.com/actions/checkout/pull/1598
 
 ## v4.1.1
-- Update CODEOWNERS to Launch team by @joshmgross in https://github.com/actions/checkout/pull/1510
 - Correct link to GitHub Docs by @peterbe in https://github.com/actions/checkout/pull/1511
 - Link to release page from what's new section by @cory-miller in https://github.com/actions/checkout/pull/1514
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v4.1.2
+- Fix: Disable sparse checkout whenever `sparse-checkout` option is not present @dscho in https://github.com/actions/checkout/pull/1598
+
+## v4.1.1
+- Update CODEOWNERS to Launch team by @joshmgross in https://github.com/actions/checkout/pull/1510
+- Correct link to GitHub Docs by @peterbe in https://github.com/actions/checkout/pull/1511
+- Link to release page from what's new section by @cory-miller in https://github.com/actions/checkout/pull/1514
+
 ## v4.1.0
 - [Add support for partial checkout filters](https://github.com/actions/checkout/pull/1396)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkout",
-  "version": "4.1.0",
+  "version": "4.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "checkout",
-      "version": "4.1.0",
+      "version": "4.1.2",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout",
-  "version": "4.1.0",
+  "version": "4.1.2",
   "description": "checkout action",
   "main": "lib/main.js",
   "scripts": {


### PR DESCRIPTION
- Add v4.1.2 and v4.1.1 to CHANGELOG.md
- Bump version in `package.json` to 4.1.2
- Ran `npm i` to regenerate `package-lock.json`