### PR TITLE
getFetchUrl: compose url with full service url

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2402,8 +2402,7 @@ function getFetchUrl(settings) {
     if (settings.sshKey) {
         return `git@${serviceUrl.hostname}:${encodedOwner}/${encodedName}.git`;
     }
-    // "origin" is SCHEME://HOSTNAME[:PORT]
-    return `${serviceUrl.origin}/${encodedOwner}/${encodedName}`;
+    return `${serviceUrl}/${encodedOwner}/${encodedName}`;
 }
 exports.getFetchUrl = getFetchUrl;
 function getServerUrl(url) {

--- a/src/url-helper.ts
+++ b/src/url-helper.ts
@@ -15,8 +15,7 @@ export function getFetchUrl(settings: IGitSourceSettings): string {
     return `git@${serviceUrl.hostname}:${encodedOwner}/${encodedName}.git`
   }
 
-  // "origin" is SCHEME://HOSTNAME[:PORT]
-  return `${serviceUrl.origin}/${encodedOwner}/${encodedName}`
+  return `${serviceUrl}/${encodedOwner}/${encodedName}`
 }
 
 export function getServerUrl(url?: string): URL {


### PR DESCRIPTION
actions/checkout maybe used by Gitea, which allows installing the server instance in a subdirectory to the service root, therefore a full serviceUrl must be used.