### PR TITLE
Update workflow and README to use github-actions[bot] user

### DIFF
--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -27,8 +27,8 @@ jobs:
         fetch-depth: 0
     - name: Git config
       run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
+        git config user.name github-actions[bot]
+        git config user.email github-actions[bot]@users.noreply.github.com
     - name: Tag new target
       run: git tag -f ${{ github.event.inputs.major_version }} ${{ github.event.inputs.target }}
     - name: Push new tag

--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           date > generated.txt
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
           git add .
           git commit -m "generated"
           git push


### PR DESCRIPTION
By setting user.email to the official github-actions[bot] email, action commits show the octocat icon with a hyperlink to https://github.com/apps/github-actions, the same way a normal user's commit shows their profile picture and links to their GitHub page.

The user.name is not important, but updated to github-actions[bot] as well for consistency.

## Before


![image](https://github.com/actions/checkout/assets/2641739/f6c020e5-288e-49c1-a4b7-d94a1cb00537)


## After

![image](https://github.com/actions/checkout/assets/2641739/fb47481e-a656-4b9a-953c-19e10c91c11d)
