### PR TITLE
Disable `extensions.worktreeConfig` when disabling `sparse-checkout`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
       - releases/*
 
 
-# Note that when you see patterns like "ref: test-data/v2/basic" within this workflow, 
+# Note that when you see patterns like "ref: test-data/v2/basic" within this workflow,
 # these refer to "test-data" branches on this actions/checkout repo.
 # (For example, test-data/v2/basic -> https://github.com/actions/checkout/tree/test-data/v2/basic)
 
@@ -37,7 +37,7 @@ jobs:
     steps:
       # Clone this repo
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       # Basic checkout
       - name: Checkout basic
@@ -257,7 +257,7 @@ jobs:
           path: basic
       - name: Verify basic
         run: __test__/verify-basic.sh --archive
-    
+
   test-git-container:
     runs-on: ubuntu-latest
     container: bitnami/git:latest

--- a/__test__/verify-basic.sh
+++ b/__test__/verify-basic.sh
@@ -18,6 +18,20 @@ else
     exit 1
   fi
 
+  # Verify that sparse-checkout is disabled.
+  SPARSE_CHECKOUT_ENABLED=$(git -C ./basic config --local --get-all core.sparseCheckout)
+  if [ "$SPARSE_CHECKOUT_ENABLED" != "" ]; then
+    echo "Expected sparse-checkout to be disabled (discovered: $SPARSE_CHECKOUT_ENABLED)"
+    exit 1
+  fi
+
+  # Verify git configuration shows worktreeConfig is effectively disabled
+  WORKTREE_CONFIG_ENABLED=$(git -C ./basic config --local --get-all extensions.worktreeConfig)
+  if [[ "$WORKTREE_CONFIG_ENABLED" != "" ]]; then
+    echo "Expected extensions.worktreeConfig (boolean) to be disabled in git config.  This could be an artifact of sparse checkout functionality."
+    exit 1
+  fi
+
   # Verify auth token
   cd basic
   git fetch --no-tags --depth=1 origin +refs/heads/main:refs/remotes/origin/main

--- a/dist/index.js
+++ b/dist/index.js
@@ -582,6 +582,8 @@ class GitCommandManager {
     disableSparseCheckout() {
         return __awaiter(this, void 0, void 0, function* () {
             yield this.execGit(['sparse-checkout', 'disable']);
+            // Disabling 'sparse-checkout` leaves behind an undesirable side-effect in config (even in a pristine environment).
+            yield this.tryConfigUnset('extensions.worktreeConfig', false);
         });
     }
     sparseCheckout(sparseCheckout) {

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -178,6 +178,8 @@ class GitCommandManager {
 
   async disableSparseCheckout(): Promise<void> {
     await this.execGit(['sparse-checkout', 'disable'])
+    // Disabling 'sparse-checkout` leaves behind an undesirable side-effect in config (even in a pristine environment).
+    await this.tryConfigUnset('extensions.worktreeConfig', false)
   }
 
   async sparseCheckout(sparseCheckout: string[]): Promise<void> {


### PR DESCRIPTION
When we released v4.1.3, there were reports that it interfered with some third party tools.

see the following issues:
- https://github.com/actions/checkout/issues/1689
- https://github.com/actions/checkout/issues/1690
- https://github.com/actions/checkout/issues/1691

It turns out that calling `git sparse-checkout disable` has a side effect.  It places the local repo clone in [worktree mode](https://git-scm.com/docs/git-worktree), albeit with only a single "tree".

This fix neutralizes that side effect by explicitly disabling worktree mode.