### PR TITLE
Update referenced `actions/checkout` version in workflows to fix `update-main-version.yml`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       # Clone this repo
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v3
 
       # Basic checkout
       - name: Checkout basic

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     # Note this update workflow can also be used as a rollback tool.
     # For that reason, it's best to pin `actions/checkout` to a known, stable version
-    # (typically, about two releases back).
+    # (typically, the previous major version -- see https://github.com/actions/checkout/pull/1705).
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -22,7 +22,7 @@ jobs:
     # Note this update workflow can also be used as a rollback tool.
     # For that reason, it's best to pin `actions/checkout` to a known, stable version
     # (typically, about two releases back).
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Git config


### PR DESCRIPTION
Based on this error text:

```
To https://github.com/actions/checkout
 ! [remote rejected] v4 -> v4 (refusing to allow a GitHub App to 
     create or update workflow `.github/workflows/test.yml` 
     without `workflows` permission)
error: failed to push some refs to 'https://github.com/actions/checkout'
```
[source](https://github.com/actions/checkout/actions/runs/8832625526/job/24250305009)

it seems it was inappropriate to update test.yml to reference a `v4*` tag.

This PR reverts that change.