### PR TITLE
Check platform to set archive extension appropriately

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1574,7 +1574,9 @@ function downloadRepository(authToken, owner, repo, ref, commit, repositoryPath,
         // Write archive to disk
         core.info('Writing archive to disk');
         const uniqueId = (0, uuid_1.v4)();
-        const archivePath = path.join(repositoryPath, `${uniqueId}.tar.gz`);
+        const archivePath = IS_WINDOWS
+            ? path.join(repositoryPath, `${uniqueId}.zip`)
+            : path.join(repositoryPath, `${uniqueId}.tar.gz`);
         yield fs.promises.writeFile(archivePath, archiveData);
         archiveData = Buffer.from(''); // Free memory
         // Extract archive

--- a/src/github-api-helper.ts
+++ b/src/github-api-helper.ts
@@ -35,7 +35,9 @@ export async function downloadRepository(
   // Write archive to disk
   core.info('Writing archive to disk')
   const uniqueId = uuid()
-  const archivePath = path.join(repositoryPath, `${uniqueId}.tar.gz`)
+  const archivePath = IS_WINDOWS
+    ? path.join(repositoryPath, `${uniqueId}.zip`)
+    : path.join(repositoryPath, `${uniqueId}.tar.gz`)
   await fs.promises.writeFile(archivePath, archiveData)
   archiveData = Buffer.from('') // Free memory
 


### PR DESCRIPTION
After updating the NPM dependencies, archive based checkouts were broken on Windows machines that do not have Git.exe in a location that `actions/checkout` understands.

This is because `@actions/tool-cache` was updated with a Powershell command `Expand-Archive`. This command explicitly checks the file name includes the `.zip` extension a the end. For whatever reason, `actions/checkout` was writing the extension as `.gz` regardless of the compression format used.

Before:

<img width="1052" alt="Screenshot 2024-05-16 at 1 32 25 PM" src="https://github.com/actions/checkout/assets/13227161/f265ca25-7288-4546-aa95-f68ece1b225d">

After:

<img width="1032" alt="Screenshot 2024-05-16 at 1 33 12 PM" src="https://github.com/actions/checkout/assets/13227161/aff140de-47ca-47aa-b687-c0736512d16c">

---

https://github.com/actions/checkout/issues/1721