### PR TITLE
Use credentials store instead of extraheader

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Please refer to the [release page](https://github.com/actions/checkout/releases/
     # Default: true
     persist-credentials: ''
 
+    # Custom git credential helper
+    custom-credential-helper: ''
+
     # Relative path under $GITHUB_WORKSPACE to place the repository
     path: ''
 

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,8 @@ inputs:
   persist-credentials:
     description: 'Whether to configure the token or SSH key with the local git config'
     default: true
+  custom-credential-helper:
+    description: 'Custom git credential helper'
   path:
     description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
   clean:

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -105,6 +105,11 @@ export interface IGitSourceSettings {
   persistCredentials: boolean
 
   /**
+   * Use following command/script as value for "credential.<URL>.helper"
+   */
+  customCredentialHelper: string | undefined
+
+  /**
    * Organization ID for the currently running workflow (used for auth settings)
    */
   workflowOrganizationId: number | undefined

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -149,6 +149,9 @@ export async function getInputs(): Promise<IGitSourceSettings> {
   result.persistCredentials =
     (core.getInput('persist-credentials') || 'false').toUpperCase() === 'TRUE'
 
+  // Custom credential helper
+  result.customCredentialHelper = core.getInput('custom-credential-helper')
+
   // Workflow organization ID
   result.workflowOrganizationId =
     await workflowContextHelper.getOrganizationId()

--- a/src/state-helper.ts
+++ b/src/state-helper.ts
@@ -26,6 +26,11 @@ export const SshKeyPath = core.getState('sshKeyPath')
 export const SshKnownHostsPath = core.getState('sshKnownHostsPath')
 
 /**
+ * The credential store path for git-credential-store
+ */
+export const CredentialStorePath = core.getState('credentialStorePath')
+
+/**
  * Save the repository path so the POST action can retrieve the value.
  */
 export function setRepositoryPath(repositoryPath: string) {
@@ -57,4 +62,11 @@ export function setSafeDirectory() {
 // This is necessary since we don't have a separate entry point.
 if (!IsPost) {
   core.saveState('isPost', 'true')
+}
+
+/**
+ * Save the credential store path so the POST action can retrieve the value.
+ */
+export function setCredentialStorePath(credentialStorePath: string) {
+  core.saveState('credentialStorePath', credentialStorePath)
 }


### PR DESCRIPTION
Since git's `extraheader` does not support different tokens and has some issue with multiple headers, this PR changes the behavior to use `credential.*.helper`. 
My use case is cloning a repository which has a lot of private submodules from different organizations. Instead of creating a machine user that has access to all organizations I want to use a Github App for that. However, each Github App installation can only see the repositories of its own organization. With multiple organizations, multiple app installations are required, each using a different token.

My solution sets `credential.helper` to `store` and creates a temporary file to which the credentials are written. This option replaces the use of `extraheader` and results in only one authentication header per request.

Additionally, a new option is provided to specify a custom credential helper via `custom-credential-helper`. This setting sets a custom command as git credential helper and can be anything. The setting `useHttpPath` to match against the path of a URL is set to true and the original credential store is used as fallback helper. However, it might be desirable to disable the default helper altogether.

Should 
fix #162
fix #415

I am open for suggestions.