### PR TITLE
docs(readme): add permissions in push example

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ jobs:
 
 ```yaml
 on: push
+# `contents:write` permission must be granted to the built-in token, see https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+permissions:
+  contents: write #Require 
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
A reminder about the required privilege to push would benefit the example of pushing with the built-in token IMHO.