### PR TITLE
Check out other refs/* by commit

### DIFF
--- a/__test__/ref-helper.test.ts
+++ b/__test__/ref-helper.test.ts
@@ -67,6 +67,16 @@ describe('ref-helper tests', () => {
     expect(checkoutInfo.startPoint).toBeFalsy()
   })
 
+  it('getCheckoutInfo refs/', async () => {
+    const checkoutInfo = await refHelper.getCheckoutInfo(
+      git,
+      'refs/gh/queue/main/pr-123',
+      commit
+    )
+    expect(checkoutInfo.ref).toBe(commit)
+    expect(checkoutInfo.startPoint).toBeFalsy()
+  })
+
   it('getCheckoutInfo unqualified branch only', async () => {
     git.branchExists = jest.fn(async (remote: boolean, pattern: string) => {
       return true

--- a/dist/index.js
+++ b/dist/index.js
@@ -2000,8 +2000,12 @@ function getCheckoutInfo(git, ref, commit) {
             result.ref = `refs/remotes/pull/${branch}`;
         }
         // refs/tags/
-        else if (upperRef.startsWith('REFS/')) {
+        else if (upperRef.startsWith('REFS/TAGS/')) {
             result.ref = ref;
+        }
+        // refs/
+        else if (upperRef.startsWith('REFS/') && commit) {
+            result.ref = commit;
         }
         // Unqualified ref, check for a matching branch or tag
         else {

--- a/src/ref-helper.ts
+++ b/src/ref-helper.ts
@@ -42,8 +42,12 @@ export async function getCheckoutInfo(
     result.ref = `refs/remotes/pull/${branch}`
   }
   // refs/tags/
-  else if (upperRef.startsWith('REFS/')) {
+  else if (upperRef.startsWith('REFS/TAGS/')) {
     result.ref = ref
+  }
+  // refs/
+  else if (upperRef.startsWith('REFS/') && commit) {
+    result.ref = commit
   }
   // Unqualified ref, check for a matching branch or tag
   else {


### PR DESCRIPTION
The code that chooses what ref to check out assumes that if something is not a branch or a pull request it must be a tag, but that is not necessarily true. When the ref is not a pull request, branch or tag, we should instead check out the commit directly.