### PR TITLE
Pin actions/checkout's own workflows to a known, good, stable version.

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.6
 
       - name: Set Node.js 20.x
         uses: actions/setup-node@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.1.6
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Check licenses
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.6
       - run: npm ci
       - run: npm run licensed-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -294,4 +294,4 @@ jobs:
       - name: Fix Checkout v4
         uses: actions/checkout@v4.1.6
         with:
-          path: v4
+          path: localClone

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.6
       - run: npm ci
       - run: npm run build
       - run: npm run format-check
@@ -37,7 +37,7 @@ jobs:
     steps:
       # Clone this repo
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.6
 
       # Basic checkout
       - name: Checkout basic
@@ -202,7 +202,7 @@ jobs:
     steps:
       # Clone this repo
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.6
 
       # Basic checkout using git
       - name: Checkout basic
@@ -234,7 +234,7 @@ jobs:
     steps:
       # Clone this repo
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.6
 
       # Basic checkout using git
       - name: Checkout basic
@@ -264,13 +264,13 @@ jobs:
     steps:
       # Clone this repo
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.6
         with:
           path: v4
 
       # Basic checkout using git
       - name: Checkout basic
-        uses: ./v4
+        uses: ./v4.1.6
         with:
           ref: test-data/v2/basic
       - name: Verify basic
@@ -292,6 +292,6 @@ jobs:
 
       # needed to make checkout post cleanup succeed
       - name: Fix Checkout v4
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.6
         with:
           path: v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,11 +266,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.6
         with:
-          path: v4
+          path: localClone
 
       # Basic checkout using git
       - name: Checkout basic
-        uses: ./v4.1.6
+        uses: ./localClone
         with:
           ref: test-data/v2/basic
       - name: Verify basic

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -22,7 +22,7 @@ jobs:
     # Note this update workflow can also be used as a rollback tool.
     # For that reason, it's best to pin `actions/checkout` to a known, stable version
     # (typically, about two releases back).
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.1.6
       with:
         fetch-depth: 0
     - name: Git config


### PR DESCRIPTION
Dependabot tried to update our internal CI workflows to the bleeding edge.  

It's safer to pin these to a specific version in order to minimize the chances of us having to jump through extra mitigation hoops in the event of a bad release.

In a roll-forward scenario, it's conceivable that a bad release could block the CI of any release candidate intended to replace it.  (It could even potentially block the `update-main-version` workflow -- a *real* chicken-and-egg problem!)  Under those circumstances, we'd have to roll-back to an older version just to get all the necessary workflows passing before we could roll forward.