### PR TITLE
Disable lfs fetch when using a fetch filter

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1306,7 +1306,7 @@ function getSource(settings) {
             // Explicit lfs-fetch to avoid slow checkout (fetches one lfs object at a time).
             // Explicit lfs fetch will fetch lfs objects in parallel.
             // For sparse checkouts, let `checkout` fetch the needed objects lazily.
-            if (settings.lfs && !settings.sparseCheckout) {
+            if (settings.lfs && !settings.sparseCheckout && !fetchOptions.filter) {
                 core.startGroup('Fetching LFS objects');
                 yield git.lfsFetch(checkoutInfo.startPoint || checkoutInfo.ref);
                 core.endGroup();


### PR DESCRIPTION
Refers to https://github.com/actions/checkout/issues/1152#issuecomment-1752027288

The `Fetching LFS objects` step fails when doing a "manual" treeless or blobless "checkout".

```
Run actions/checkout@v4
  with:
    filter: blob:none
    fetch-depth: 0
    lfs: true
    repository: company-com/myproject
    token: ***
    ssh-strict: true
    ssh-user: git
    persist-credentials: true
    clean: true
    sparse-checkout-cone-mode: true
    fetch-tags: false
    show-progress: true
    submodules: false
    set-safe-directory: true
Syncing repository: company-com/myproject
Getting Git version info
Temporarily overriding HOME='/home/runner/work/_temp/e654cc30-b5f1-4c0c-9d1e-69d2d9119211' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
/usr/bin/git config --global --add safe.directory /home/runner/work/myproject/myproject
Deleting the contents of '/home/runner/work/myproject/myproject'
Initializing the repository
Disabling automatic garbage collection
Setting up auth
/usr/bin/git lfs install --local
Updated Git hooks.
Git LFS initialized.
Fetching the repository
Determining the checkout info
Fetching LFS objects
  /usr/bin/git lfs fetch origin refs/remotes/pull/22/merge
  fetch: Fetching reference refs/remotes/pull/22/merge
  Could not scan for Git LFS files
  
  Errors logged to '/home/runner/work/myproject/myproject/.git/lfs/logs/20240625T135006.343299849.log'.
  Use `git lfs logs last` to view the log.
  The process '/usr/bin/git' failed with exit code 2
  Waiting 10 seconds before trying again
  /usr/bin/git lfs fetch origin refs/remotes/pull/22/merge
  fetch: Fetching reference refs/remotes/pull/22/merge
  Could not scan for Git LFS files
  
  Errors logged to '/home/runner/work/myproject/myproject/.git/lfs/logs/20240625T135016.59069056.log'.
  Use `git lfs logs last` to view the log.
  The process '/usr/bin/git' failed with exit code 2
  Waiting 20 seconds before trying again
  /usr/bin/git lfs fetch origin refs/remotes/pull/22/merge
  fetch: Fetching reference refs/remotes/pull/22/merge
  Could not scan for Git LFS files
  
  Errors logged to '/home/runner/work/myproject/myproject/.git/lfs/logs/20240625T135036.863695316.log'.
  Use `git lfs logs last` to view the log.
  Error: The process '/usr/bin/git' failed with exit code 2
```