### PR TITLE
Revert "Bump docker/build-push-action from 5.3.0 to 6.5.0 (#1832)"

### DIFF
--- a/.github/workflows/update-test-ubuntu-git.yml
+++ b/.github/workflows/update-test-ubuntu-git.yml
@@ -48,7 +48,7 @@ jobs:
 
       # Use `docker/build-push-action` to build (and optionally publish) the image. 
       - name: Build Docker Image (with optional Push)
-        uses: docker/build-push-action@v6.5.0
+        uses: docker/build-push-action@v5.3.0
         with:
           context: .
           file: images/test-ubuntu-git.Dockerfile


### PR DESCRIPTION
This reverts commit 9a9194f87191a7e9055e3e9b95b8cfb13023bb08.