### PR TITLE
feature: add support for `commit` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Please refer to the [release page](https://github.com/actions/checkout/releases/
     # Otherwise, uses the default branch.
     ref: ''
 
+    # The commit SHA to checkout. Used when ref is not specified or is ambiguous. This
+    # can be used as a replacement for ref, or alongside it to checkout a specific
+    # commit of the ref.
+    commit: ''
+
     # Personal access token (PAT) used to fetch the repository. The PAT is configured
     # with the local git config, which enables your scripts to run authenticated git
     # commands. The post-job step removes the PAT.

--- a/__test__/input-helper.test.ts
+++ b/__test__/input-helper.test.ts
@@ -153,7 +153,9 @@ describe('input-helper tests', () => {
     expect(settings.ref).toBeTruthy()
     expect(settings.ref).toStrictEqual('refs/pull/123/merge')
     expect(settings.commit).toBeTruthy()
-    expect(settings.commit).toStrictEqual('0123456789012345678901234567890123456789')
+    expect(settings.commit).toStrictEqual(
+      '0123456789012345678901234567890123456789'
+    )
   })
 
   it('ref fallbacks to commit if ref is empty but commit is specified', async () => {
@@ -162,8 +164,12 @@ describe('input-helper tests', () => {
     const settings: IGitSourceSettings = await inputHelper.getInputs()
     expect(settings).toBeTruthy()
     expect(settings.ref).toBeTruthy()
-    expect(settings.ref).toStrictEqual('0123456789012345678901234567890123456789')
+    expect(settings.ref).toStrictEqual(
+      '0123456789012345678901234567890123456789'
+    )
     expect(settings.commit).toBeTruthy()
-    expect(settings.commit).toStrictEqual('0123456789012345678901234567890123456789')
+    expect(settings.commit).toStrictEqual(
+      '0123456789012345678901234567890123456789'
+    )
   })
 })

--- a/__test__/input-helper.test.ts
+++ b/__test__/input-helper.test.ts
@@ -144,4 +144,26 @@ describe('input-helper tests', () => {
     const settings: IGitSourceSettings = await inputHelper.getInputs()
     expect(settings.workflowOrganizationId).toBe(123456)
   })
+
+  it('accepts ref and commit', async () => {
+    inputs.ref = 'refs/pull/123/merge'
+    inputs.commit = '0123456789012345678901234567890123456789'
+    const settings: IGitSourceSettings = await inputHelper.getInputs()
+    expect(settings).toBeTruthy()
+    expect(settings.ref).toBeTruthy()
+    expect(settings.ref).toStrictEqual('refs/pull/123/merge')
+    expect(settings.commit).toBeTruthy()
+    expect(settings.commit).toStrictEqual('0123456789012345678901234567890123456789')
+  })
+
+  it('ref fallbacks to commit if ref is empty but commit is specified', async () => {
+    inputs.ref = ''
+    inputs.commit = '0123456789012345678901234567890123456789'
+    const settings: IGitSourceSettings = await inputHelper.getInputs()
+    expect(settings).toBeTruthy()
+    expect(settings.ref).toBeTruthy()
+    expect(settings.ref).toStrictEqual('0123456789012345678901234567890123456789')
+    expect(settings.commit).toBeTruthy()
+    expect(settings.commit).toStrictEqual('0123456789012345678901234567890123456789')
+  })
 })

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,11 @@ inputs:
       The branch, tag or SHA to checkout. When checking out the repository that
       triggered a workflow, this defaults to the reference or SHA for that
       event.  Otherwise, uses the default branch.
+  commit:
+    description: >
+      The commit SHA to checkout. Used when ref is not specified or is ambiguous.
+      This can be used as a replacement for ref, or alongside it to checkout a
+      specific commit of the ref.
   token:
     description: >
       Personal access token (PAT) used to fetch the repository. The PAT is configured

--- a/dist/index.js
+++ b/dist/index.js
@@ -1717,6 +1717,7 @@ const path = __importStar(__nccwpck_require__(1017));
 const workflowContextHelper = __importStar(__nccwpck_require__(9568));
 function getInputs() {
     return __awaiter(this, void 0, void 0, function* () {
+        var _a;
         const result = {};
         // GitHub workspace
         let githubWorkspacePath = process.env['GITHUB_WORKSPACE'];
@@ -1748,7 +1749,11 @@ function getInputs() {
         const isWorkflowRepository = qualifiedRepository.toUpperCase() ===
             `${github.context.repo.owner}/${github.context.repo.repo}`.toUpperCase();
         // Source branch, source version
-        result.ref = core.getInput('ref');
+        result.commit = core.getInput('commit');
+        if (result.commit && !result.commit.match(/^[0-9a-fA-F]{40}$/)) {
+            throw new Error(`The commit SHA '${result.commit}' is not a valid SHA.`);
+        }
+        result.ref = (_a = core.getInput('ref')) !== null && _a !== void 0 ? _a : result.commit;
         if (!result.ref) {
             if (isWorkflowRepository) {
                 result.ref = github.context.ref;

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -58,6 +58,10 @@ export async function getInputs(): Promise<IGitSourceSettings> {
 
   // Source branch, source version
   result.commit = core.getInput('commit')
+  if (result.commit && !result.commit.match(/^[0-9a-fA-F]{40}$/)) {
+    throw new Error(`The commit SHA '${result.commit}' is not a valid SHA.`)
+  }
+
   result.ref = core.getInput('ref') ?? result.commit
   if (!result.ref) {
     if (isWorkflowRepository) {

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -57,6 +57,7 @@ export async function getInputs(): Promise<IGitSourceSettings> {
     `${github.context.repo.owner}/${github.context.repo.repo}`.toUpperCase()
 
   // Source branch, source version
+  result.commit = core.getInput('commit')
   result.ref = core.getInput('ref')
   if (!result.ref) {
     if (isWorkflowRepository) {

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -58,7 +58,7 @@ export async function getInputs(): Promise<IGitSourceSettings> {
 
   // Source branch, source version
   result.commit = core.getInput('commit')
-  result.ref = core.getInput('ref')
+  result.ref = core.getInput('ref') ?? result.commit
   if (!result.ref) {
     if (isWorkflowRepository) {
       result.ref = github.context.ref


### PR DESCRIPTION
Fixes #1634

This pull request adds support for supplying a commit input. This is necessary in order to replicate the standard behavior in pull request synchronization events when not using the default values.

| Commit | Summary |
| :-- | :-- |
| #650ceb0 | Adds a `commit` input in the `action.yaml` file |
| #67b5caa | Modifies `settings.commit` to equal the `commit` input before applying the default value if the input for ref is not found. |
| #8a241b5 | Make `settings.ref` fallback to `settings.commit` if the `commit` input is provided but not `ref` input |
| #267ca9c | Add validation to the `commit` input, to make sure that the input is a string of 40 hexadecimal characters. |
| #3a6c8fb | Added tests to verify the behavior of this pull request. |
| #491fae0 | Result of running `npm run format` |
| #a52fa92 #1be0f94 | Result of running `npm run build` |