### PR TITLE
Expand unit test coverage for `isGhes`

### DIFF
--- a/__test__/url-helper.test.ts
+++ b/__test__/url-helper.test.ts
@@ -24,12 +24,49 @@ describe('getServerUrl tests', () => {
 })
 
 describe('isGhes tests', () => {
+  const pristineEnv = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = {...pristineEnv}
+  })
+
+  afterAll(() => {
+    process.env = pristineEnv
+  })
+
   it('basics', async () => {
+    delete process.env['GITHUB_SERVER_URL']
     expect(urlHelper.isGhes()).toBeFalsy()
     expect(urlHelper.isGhes('https://github.com')).toBeFalsy()
     expect(urlHelper.isGhes('https://contoso.ghe.com')).toBeFalsy()
     expect(urlHelper.isGhes('https://test.github.localhost')).toBeFalsy()
     expect(urlHelper.isGhes('https://src.onpremise.fabrikam.com')).toBeTruthy()
+  })
+
+  it('returns false when the GITHUB_SERVER_URL environment variable is not defined', async () => {
+    delete process.env['GITHUB_SERVER_URL']
+    expect(urlHelper.isGhes()).toBeFalsy()
+  })
+
+  it('returns false when the GITHUB_SERVER_URL environment variable is set to github.com', async () => {
+    process.env['GITHUB_SERVER_URL'] = 'https://github.com'
+    expect(urlHelper.isGhes()).toBeFalsy()
+  })
+
+  it('returns false when the GITHUB_SERVER_URL environment variable is set to a GitHub Enterprise Cloud-style URL', async () => {
+    process.env['GITHUB_SERVER_URL'] = 'https://contoso.ghe.com'
+    expect(urlHelper.isGhes()).toBeFalsy()
+  })
+
+  it('returns false when the GITHUB_SERVER_URL environment variable has a .localhost suffix', async () => {
+    process.env['GITHUB_SERVER_URL'] = 'https://mock-github.localhost'
+    expect(urlHelper.isGhes()).toBeFalsy()
+  })
+
+  it('returns true when the GITHUB_SERVER_URL environment variable is set to some other URL', async () => {
+    process.env['GITHUB_SERVER_URL'] = 'https://src.onpremise.fabrikam.com'
+    expect(urlHelper.isGhes()).toBeTruthy()
   })
 })
 


### PR DESCRIPTION
`isGhes` is an exported function that was lacking unit test coverage.  This PR adds unit tests for `isGhes`.