### PR TITLE
Implement allow-path-outside-workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Please refer to the [release page](https://github.com/actions/checkout/releases/
     # Relative path under $GITHUB_WORKSPACE to place the repository
     path: ''
 
+    # Allow the checked-out repository to be placed outside of the workspace
+    # Default: false
+    allow-path-outside-workspace: ''
+
     # Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching
     # Default: true
     clean: ''

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,10 @@ inputs:
     default: true
   path:
     description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
+  allow-path-outside-workspace:
+    description: Allow the checked-out repository to be placed outside of the workspace.
+    default: false
+    required: false
   clean:
     description: 'Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching'
     default: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -1737,7 +1737,8 @@ function getInputs() {
         // Repository path
         result.repositoryPath = core.getInput('path') || '.';
         result.repositoryPath = path.resolve(githubWorkspacePath, result.repositoryPath);
-        if (!(result.repositoryPath + path.sep).startsWith(githubWorkspacePath + path.sep)) {
+        if (!core.getInput('allow-path-outside-workspace') &&
+            !(result.repositoryPath + path.sep).startsWith(githubWorkspacePath + path.sep)) {
             throw new Error(`Repository path '${result.repositoryPath}' is not under '${githubWorkspacePath}'`);
         }
         // Workflow repository?

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -42,6 +42,7 @@ export async function getInputs(): Promise<IGitSourceSettings> {
     result.repositoryPath
   )
   if (
+    !core.getInput('allow-path-outside-workspace') &&
     !(result.repositoryPath + path.sep).startsWith(
       githubWorkspacePath + path.sep
     )


### PR DESCRIPTION
**Problem**
For my use case, I need to reduce the size of my checkout path due C++ compiler file path limit.

**Solution**
Implement `allow-path-outside-workspace` attribute to enable the possibility to checkout in a shorter path than github_workspace.