### PR TITLE
Draft: Add support for SHA256 repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Please refer to the [release page](https://github.com/actions/checkout/releases/
     # running from unless specified. Example URLs are https://github.com or
     # https://my-ghes-server.example.com
     github-server-url: ''
+
+    # Set Git object format to "sha256" when initializing a Git repository.
+    # Default: false
+    repo-sha256: ''
 ```
 <!-- end usage -->
 

--- a/action.yml
+++ b/action.yml
@@ -98,6 +98,10 @@ inputs:
   github-server-url:
     description: The base URL for the GitHub instance that you are trying to clone from, will use environment defaults to fetch from the same instance that the workflow is running from unless specified. Example URLs are https://github.com or https://my-ghes-server.example.com
     required: false
+  repo-sha256:
+    description: 'Set Git object format to "sha256" when initializing a Git repository.'
+    required: false
+    default: false
 outputs:
   ref:
     description: 'The branch, tag or SHA that was checked out'

--- a/dist/index.js
+++ b/dist/index.js
@@ -709,9 +709,14 @@ class GitCommandManager {
     getWorkingDirectory() {
         return this.workingDirectory;
     }
-    init() {
+    init(repoSHA256) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield this.execGit(['init', this.workingDirectory]);
+            const args = ['init'];
+            if (repoSHA256) {
+                args.push(`--object-format=sha256`);
+            }
+            args.push(this.workingDirectory);
+            yield this.execGit(args);
         });
     }
     isDetached() {
@@ -1236,7 +1241,7 @@ function getSource(settings) {
             // Initialize the repository
             if (!fsHelper.directoryExistsSync(path.join(settings.repositoryPath, '.git'))) {
                 core.startGroup('Initializing the repository');
-                yield git.init();
+                yield git.init(settings.repoSHA256);
                 yield git.remoteAdd('origin', repositoryUrl);
                 core.endGroup();
             }
@@ -1831,6 +1836,10 @@ function getInputs() {
         // Determine the GitHub URL that the repository is being hosted from
         result.githubServerUrl = core.getInput('github-server-url');
         core.debug(`GitHub Host URL = ${result.githubServerUrl}`);
+        // Set Git object format to "sha256" when initializing a Git repository.
+        result.repoSHA256 =
+            (core.getInput('repo-sha256') || 'false').toUpperCase() === 'TRUE';
+        core.debug(`Repo object format sha256 = ${result.repoSHA256}`);
         return result;
     });
 }

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -42,7 +42,7 @@ export interface IGitCommandManager {
   ): Promise<void>
   getDefaultBranch(repositoryUrl: string): Promise<string>
   getWorkingDirectory(): string
-  init(): Promise<void>
+  init(repoSHA256?: boolean): Promise<void>
   isDetached(): Promise<boolean>
   lfsFetch(ref: string): Promise<void>
   lfsInstall(): Promise<void>
@@ -327,8 +327,13 @@ class GitCommandManager {
     return this.workingDirectory
   }
 
-  async init(): Promise<void> {
-    await this.execGit(['init', this.workingDirectory])
+  async init(repoSHA256?: boolean): Promise<void> {
+    const args = ['init']
+    if (repoSHA256) {
+      args.push(`--object-format=sha256`)
+    }
+    args.push(this.workingDirectory)
+    await this.execGit(args)
   }
 
   async isDetached(): Promise<boolean> {

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -110,7 +110,7 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
       !fsHelper.directoryExistsSync(path.join(settings.repositoryPath, '.git'))
     ) {
       core.startGroup('Initializing the repository')
-      await git.init()
+      await git.init(settings.repoSHA256)
       await git.remoteAdd('origin', repositoryUrl)
       core.endGroup()
     }

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -118,4 +118,9 @@ export interface IGitSourceSettings {
    * User override on the GitHub Server/Host URL that hosts the repository to be cloned
    */
   githubServerUrl: string | undefined
+
+  /**
+   * Set Git object format to "sha256" when initializing a Git repository
+   */
+  repoSHA256: boolean
 }

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -161,5 +161,10 @@ export async function getInputs(): Promise<IGitSourceSettings> {
   result.githubServerUrl = core.getInput('github-server-url')
   core.debug(`GitHub Host URL = ${result.githubServerUrl}`)
 
+  // Set Git object format to "sha256" when initializing a Git repository.
+  result.repoSHA256 =
+    (core.getInput('repo-sha256') || 'false').toUpperCase() === 'TRUE'
+  core.debug(`Repo object format sha256 = ${result.repoSHA256}`)
+
   return result
 }


### PR DESCRIPTION
New input parameter 'repo-sha256' to set the Git object format to "sha256" when initializing a Git repository.