### PR TITLE
fix: sparse-checkout not disabled on subsequent checkout

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -588,6 +588,8 @@ class GitCommandManager {
     disableSparseCheckout() {
         return __awaiter(this, void 0, void 0, function* () {
             yield this.execGit(['sparse-checkout', 'disable']);
+            // Ensures that a previously enabled 'sparse-checkout' (e.g. via sparseCheckoutNonConeMode) is also disabled in the config.
+            yield this.execGit(['config', 'core.sparseCheckout', 'false']);
             // Disabling 'sparse-checkout` leaves behind an undesirable side-effect in config (even in a pristine environment).
             yield this.tryConfigUnset('extensions.worktreeConfig', false);
         });

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -178,6 +178,8 @@ class GitCommandManager {
 
   async disableSparseCheckout(): Promise<void> {
     await this.execGit(['sparse-checkout', 'disable'])
+    // Ensures that a previously enabled 'sparse-checkout' (e.g. via sparseCheckoutNonConeMode) is also disabled in the config.
+    yield this.execGit(['config', 'core.sparseCheckout', 'false']);
     // Disabling 'sparse-checkout` leaves behind an undesirable side-effect in config (even in a pristine environment).
     await this.tryConfigUnset('extensions.worktreeConfig', false)
   }


### PR DESCRIPTION
If actions/checkout is invoked once with `sparse-checkout` and cone mode disabled, `core.sparseCheckout` remains enabled for all subsequent invocations of actions/checkout.

This PR addresses the problem by explicitly (re)setting `core.sparseCheckout` to `false`.

Reproduction:

```yaml
    steps:
      - uses: actions/checkout@v4
        with:
          ref: mybranch
          sparse-checkout-cone-mode: false
          sparse-checkout: /my.config

     # $ ls
     # /my.config

      - uses: actions/checkout@v4
        with:
          ref: mybranch

     # $ ls
     # /my.config
```