### PR TITLE
Ask git to checkout a submodule even if it is skipped in `.gitmodules`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -796,7 +796,7 @@ class GitCommandManager {
     submoduleUpdate(fetchDepth, recursive) {
         return __awaiter(this, void 0, void 0, function* () {
             const args = ['-c', 'protocol.version=2'];
-            args.push('submodule', 'update', '--init', '--force');
+            args.push('submodule', 'update', '--init', '--force', '--checkout');
             if (fetchDepth > 0) {
                 args.push(`--depth=${fetchDepth}`);
             }

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -411,7 +411,7 @@ class GitCommandManager {
 
   async submoduleUpdate(fetchDepth: number, recursive: boolean): Promise<void> {
     const args = ['-c', 'protocol.version=2']
-    args.push('submodule', 'update', '--init', '--force')
+    args.push('submodule', 'update', '--init', '--force', '--checkout')
     if (fetchDepth > 0) {
       args.push(`--depth=${fetchDepth}`)
     }


### PR DESCRIPTION
Setting a submodule as `update = none` is a common way to make cargo skip the submodule. Unfortunately this makes `actions/checkout` skip the submodule too, even if it's configured to fetch submodules.

This patch adds an option that is a default in git but causes the submodules to be available even if skipped otherwise.

See: https://github.com/actions/checkout/issues/915
See: https://github.com/rust-lang/cargo/issues/4247#issuecomment-1149178736
See: https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt---checkout