### PR TITLE
feat(git config): set default branch name on initialization to main

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -711,6 +711,7 @@ class GitCommandManager {
     }
     init() {
         return __awaiter(this, void 0, void 0, function* () {
+            yield this.config('init.defaultBranch', 'main', true, true);
             yield this.execGit(['init', this.workingDirectory]);
         });
     }

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -328,6 +328,7 @@ class GitCommandManager {
   }
 
   async init(): Promise<void> {
+    await this.config('init.defaultBranch', 'main', true, true)
     await this.execGit(['init', this.workingDirectory])
   }
 


### PR DESCRIPTION
Sets the default branch name for new initialized repositories. This is to stop the following help messages from being printed during a CI run.

<img width="1024" alt="Screenshot 2025-03-29 at 5 15 22 PM" src="https://github.com/user-attachments/assets/833abdd6-04cf-4274-8a17-e6303292f287" />
