### PR TITLE
Add `exclude_from_clean` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 [![Build and Test](https://github.com/actions/checkout/actions/workflows/test.yml/badge.svg)](https://github.com/actions/checkout/actions/workflows/test.yml)
 
+Changes compared to https://github.com/actions/checkout:
+- Can exclude path when cleaning repository (see `exclude_from_clean` argument)
+
 # Checkout V4
 
 This action checks-out your repository under `$GITHUB_WORKSPACE`, so your workflow can access it.
@@ -77,6 +80,9 @@ Please refer to the [release page](https://github.com/actions/checkout/releases/
     # Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching
     # Default: true
     clean: ''
+
+    # The path to exclude from cleaning
+    exclude_from_clean: ''
 
     # Partially clone against a given filter. Overrides sparse-checkout if set.
     # Default: null

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,8 @@ inputs:
   clean:
     description: 'Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching'
     default: true
+  exclude_from_clean:
+    description: 'The path to exclude from cleaning'
   filter:
     description: >
       Partially clone against a given filter.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkout",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkout",
-      "version": "4.2.2",
+      "version": "4.2.3",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "checkout action",
   "main": "lib/main.js",
   "scripts": {

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -57,7 +57,7 @@ export interface IGitCommandManager {
   submoduleUpdate(fetchDepth: number, recursive: boolean): Promise<void>
   submoduleStatus(): Promise<boolean>
   tagExists(pattern: string): Promise<boolean>
-  tryClean(): Promise<boolean>
+  tryClean(exclude_from_clean: string): Promise<boolean>
   tryConfigUnset(configKey: string, globalConfig?: boolean): Promise<boolean>
   tryDisableAutomaticGarbageCollection(): Promise<boolean>
   tryGetFetchUrl(): Promise<string>
@@ -434,8 +434,13 @@ class GitCommandManager {
     return !!output.stdout.trim()
   }
 
-  async tryClean(): Promise<boolean> {
-    const output = await this.execGit(['clean', '-ffdx'], true)
+  async tryClean(exclude_from_clean: string): Promise<boolean> {
+    let output
+    if (exclude_from_clean) {
+      output = await this.execGit(['clean', '-ffdx', '-e', exclude_from_clean], true)
+    } else {
+      output = await this.execGit(['clean', '-ffdx'], true)
+    }
     return output.exitCode === 0
   }
 

--- a/src/git-directory-helper.ts
+++ b/src/git-directory-helper.ts
@@ -11,6 +11,7 @@ export async function prepareExistingDirectory(
   repositoryPath: string,
   repositoryUrl: string,
   clean: boolean,
+  exclude_from_clean: string,
   ref: string
 ): Promise<void> {
   assert.ok(repositoryPath, 'Expected repositoryPath to be defined')
@@ -90,7 +91,7 @@ export async function prepareExistingDirectory(
       // Clean
       if (clean) {
         core.startGroup('Cleaning the repository')
-        if (!(await git.tryClean())) {
+        if (!(await git.tryClean(exclude_from_clean))) {
           core.debug(
             `The clean command failed. This might be caused by: 1) path too long, 2) permission issue, or 3) file in use. For further investigation, manually run 'git clean -ffdx' on the directory '${repositoryPath}'.`
           )

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -70,6 +70,7 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
         settings.repositoryPath,
         repositoryUrl,
         settings.clean,
+        settings.exclude_from_clean,
         settings.ref
       )
     }

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -30,6 +30,11 @@ export interface IGitSourceSettings {
   clean: boolean
 
   /**
+   * Indicates path to exclude when cleaning
+   */
+  exclude_from_clean: string
+
+  /**
    * The filter determining which objects to include
    */
   filter: string | undefined

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -82,6 +82,10 @@ export async function getInputs(): Promise<IGitSourceSettings> {
   result.clean = (core.getInput('clean') || 'true').toUpperCase() === 'TRUE'
   core.debug(`clean = ${result.clean}`)
 
+  // Exclude from clean
+  result.exclude_from_clean = core.getInput('exclude_from_clean')
+  core.debug(`exclude_from_clean = ${result.exclude_from_clean}`)
+
   // Filter
   const filter = core.getInput('filter')
   if (filter) {


### PR DESCRIPTION
See: https://github.com/actions/checkout/issues/862

Adds a `exclude_from_clean` option, which exclude the specified path from the `clean` operation. More concretely, if a value is provided, the action runs `git clean -ffdx -e <exclude_from_clean>`  instead of running `git clean -ffdx`.

This is particularly useful for self-hosted runners, where deleting and re-creating certain directories can sometimes be inneficient and costly (examples: `node_modules`, git LFS files)