### PR TITLE
feat(inputs): add option to disable the post action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,6 +98,10 @@ inputs:
   github-server-url:
     description: The base URL for the GitHub instance that you are trying to clone from, will use environment defaults to fetch from the same instance that the workflow is running from unless specified. Example URLs are https://github.com or https://my-ghes-server.example.com
     required: false
+  skip-cleanup:
+    description: Skips the cleanup phase on post action hook
+    required: false
+    default: false
 outputs:
   ref:
     description: 'The branch, tag or SHA that was checked out'

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -118,4 +118,9 @@ export interface IGitSourceSettings {
    * User override on the GitHub Server/Host URL that hosts the repository to be cloned
    */
   githubServerUrl: string | undefined
+
+  /**
+   * Disable the post action cleanup phase
+   */
+  skipCleanup: boolean
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,12 @@ async function run(): Promise<void> {
 }
 
 async function cleanup(): Promise<void> {
+  const sourceSettings = await inputHelper.getInputs()
+
+  if (sourceSettings.skipCleanup) {
+    return
+  }
+
   try {
     await gitSourceProvider.cleanup(stateHelper.RepositoryPath)
   } catch (error) {


### PR DESCRIPTION
Add an option to disable the post-hook of checkout. This will enable people to run private github actions within other workflows without having to hack around like this:

https://github.com/actions/checkout/issues/1149#issuecomment-2095454685

fixes: #1149
fixes: #2164
