### PR TITLE
Preserve local changes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ Please refer to the [release page](https://github.com/actions/checkout/releases/
     clean: ''
 
     # Whether to preserve local changes during checkout. If true, tries to preserve
-    # local files that are not tracked by Git. By default, all files will be overwritten.
+    # local files that are not tracked by Git. By default, all files will be
+    # overwritten.
     # Default: false
-    preserveLocalChanges: ''
+    preserve-local-changes: ''
 
     # Partially clone against a given filter. Overrides sparse-checkout if set.
     # Default: null
@@ -349,7 +350,7 @@ steps:
     uses: actions/checkout@v5
     with:
       clean: false
-      preserveLocalChanges: true
+      preserve-local-changes: true
 ```
 
 # Recommended permissions

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ Please refer to the [release page](https://github.com/actions/checkout/releases/
     # Default: true
     clean: ''
 
+    # Whether to preserve local changes during checkout. If true, tries to preserve
+    # local files that are not tracked by Git. By default, all files will be overwritten.
+    # Default: false
+    preserveLocalChanges: ''
+
     # Partially clone against a given filter. Overrides sparse-checkout if set.
     # Default: null
     filter: ''
@@ -331,6 +336,21 @@ jobs:
 ```
 
 *NOTE:* The user email is `{user.id}+{user.login}@users.noreply.github.com`. See users API: https://api.github.com/users/github-actions%5Bbot%5D
+
+## Preserve local changes during checkout
+
+```yaml
+steps:
+  - name: Create file before checkout
+    shell: pwsh
+    run: New-Item -Path . -Name "example.txt" -ItemType "File"
+    
+  - name: Checkout with preserving local changes
+    uses: actions/checkout@v5
+    with:
+      clean: false
+      preserveLocalChanges: true
+```
 
 # Recommended permissions
 

--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -814,6 +814,7 @@ async function setup(testName: string): Promise<void> {
     submodules: false,
     nestedSubmodules: false,
     persistCredentials: true,
+    preserveLocalChanges: false,
     ref: 'refs/heads/main',
     repositoryName: 'my-repo',
     repositoryOwner: 'my-org',

--- a/__test__/git-directory-helper.test.ts
+++ b/__test__/git-directory-helper.test.ts
@@ -143,12 +143,13 @@ describe('git-directory-helper tests', () => {
       repositoryPath,
       repositoryUrl,
       clean,
-      ref
+      ref,
+      false // preserveLocalChanges = false
     )
 
     // Assert
     const files = await fs.promises.readdir(repositoryPath)
-    expect(files).toHaveLength(0)
+    expect(files).toEqual(['.git']) // Expect just the .git directory to remain
     expect(git.tryClean).toHaveBeenCalled()
     expect(core.warning).toHaveBeenCalled()
     expect(git.tryReset).not.toHaveBeenCalled()
@@ -170,12 +171,13 @@ describe('git-directory-helper tests', () => {
       repositoryPath,
       differentRepositoryUrl,
       clean,
-      ref
+      ref,
+      false // preserveLocalChanges = false
     )
 
     // Assert
     const files = await fs.promises.readdir(repositoryPath)
-    expect(files).toHaveLength(0)
+    expect(files).toEqual(['.git']) // Expect just the .git directory to remain
     expect(core.warning).not.toHaveBeenCalled()
     expect(git.isDetached).not.toHaveBeenCalled()
   })
@@ -221,12 +223,13 @@ describe('git-directory-helper tests', () => {
       repositoryPath,
       repositoryUrl,
       clean,
-      ref
+      ref,
+      false // preserveLocalChanges = false
     )
 
     // Assert
     const files = await fs.promises.readdir(repositoryPath)
-    expect(files).toHaveLength(0)
+    expect(files).toEqual(['.git']) // Expect just the .git directory to remain
     expect(git.tryClean).toHaveBeenCalled()
     expect(git.tryReset).toHaveBeenCalled()
     expect(core.warning).toHaveBeenCalled()
@@ -246,12 +249,13 @@ describe('git-directory-helper tests', () => {
       repositoryPath,
       repositoryUrl,
       clean,
-      ref
+      ref,
+      false // preserveLocalChanges = false
     )
 
     // Assert
     const files = await fs.promises.readdir(repositoryPath)
-    expect(files).toHaveLength(0)
+    expect(files).toEqual(['.git']) // Expect just the .git directory to remain
     expect(core.warning).not.toHaveBeenCalled()
   })
 
@@ -302,12 +306,13 @@ describe('git-directory-helper tests', () => {
       repositoryPath,
       repositoryUrl,
       clean,
-      ref
+      ref,
+      false // preserveLocalChanges = false
     )
 
     // Assert
     const files = await fs.promises.readdir(repositoryPath)
-    expect(files).toHaveLength(0)
+    expect(files).toEqual(['.git']) // Expect just the .git directory to remain
     expect(git.tryClean).toHaveBeenCalled()
   })
 

--- a/__test__/git-directory-helper.test.ts
+++ b/__test__/git-directory-helper.test.ts
@@ -154,6 +154,34 @@ describe('git-directory-helper tests', () => {
     expect(core.warning).toHaveBeenCalled()
     expect(git.tryReset).not.toHaveBeenCalled()
   })
+  
+  const preservesContentsWhenCleanFailsAndPreserveLocalChanges = 'preserves contents when clean fails and preserve-local-changes is true'
+  it(preservesContentsWhenCleanFailsAndPreserveLocalChanges, async () => {
+    // Arrange
+    await setup(preservesContentsWhenCleanFailsAndPreserveLocalChanges)
+    await fs.promises.writeFile(path.join(repositoryPath, 'my-file'), '')
+    let mockTryClean = git.tryClean as jest.Mock<any, any>
+    mockTryClean.mockImplementation(async () => {
+      return false
+    })
+
+    // Act
+    await gitDirectoryHelper.prepareExistingDirectory(
+      git,
+      repositoryPath,
+      repositoryUrl,
+      clean,
+      ref,
+      true // preserveLocalChanges = true
+    )
+
+    // Assert
+    const files = await fs.promises.readdir(repositoryPath)
+    expect(files.sort()).toEqual(['.git', 'my-file']) // Expect both .git and user files to remain
+    expect(git.tryClean).toHaveBeenCalled()
+    expect(core.warning).toHaveBeenCalled()
+    expect(git.tryReset).not.toHaveBeenCalled()
+  })
 
   const removesContentsWhenDifferentRepositoryUrl =
     'removes contents when different repository url'
@@ -180,6 +208,39 @@ describe('git-directory-helper tests', () => {
     expect(files).toEqual(['.git']) // Expect just the .git directory to remain
     expect(core.warning).not.toHaveBeenCalled()
     expect(git.isDetached).not.toHaveBeenCalled()
+  })
+
+  const keepsContentsWhenDifferentRepositoryUrlAndPreserveLocalChanges =
+    'keeps contents when different repository url and preserve-local-changes is true'
+  it(keepsContentsWhenDifferentRepositoryUrlAndPreserveLocalChanges, async () => {
+    // Arrange
+    await setup(keepsContentsWhenDifferentRepositoryUrlAndPreserveLocalChanges)
+    clean = false
+    
+    // Create a file that we expect to be preserved
+    await fs.promises.writeFile(path.join(repositoryPath, 'my-file'), '')
+    
+    // Simulate a different repository by simply removing the .git directory
+    await io.rmRF(path.join(repositoryPath, '.git'))
+    await fs.promises.mkdir(path.join(repositoryPath, '.git'))
+    
+    const differentRepositoryUrl = 'https://github.com/my-different-org/my-different-repo'
+    
+    // Act
+    await gitDirectoryHelper.prepareExistingDirectory(
+      git,
+      repositoryPath,
+      differentRepositoryUrl, // Use a different URL
+      clean,
+      ref,
+      true // preserveLocalChanges = true
+    )
+
+    // Assert
+    const files = await fs.promises.readdir(repositoryPath)
+    console.log('Files after operation:', files)
+    // When preserveLocalChanges is true, files should be preserved even with different repo URL
+    expect(files.sort()).toEqual(['.git', 'my-file'].sort())
   })
 
   const removesContentsWhenNoGitDirectory =
@@ -230,6 +291,34 @@ describe('git-directory-helper tests', () => {
     // Assert
     const files = await fs.promises.readdir(repositoryPath)
     expect(files).toEqual(['.git']) // Expect just the .git directory to remain
+    expect(git.tryClean).toHaveBeenCalled()
+    expect(git.tryReset).toHaveBeenCalled()
+    expect(core.warning).toHaveBeenCalled()
+  })
+
+  const preservesContentsWhenResetFailsAndPreserveLocalChanges = 'preserves contents when reset fails and preserve-local-changes is true'
+  it(preservesContentsWhenResetFailsAndPreserveLocalChanges, async () => {
+    // Arrange
+    await setup(preservesContentsWhenResetFailsAndPreserveLocalChanges)
+    await fs.promises.writeFile(path.join(repositoryPath, 'my-file'), '')
+    let mockTryReset = git.tryReset as jest.Mock<any, any>
+    mockTryReset.mockImplementation(async () => {
+      return false
+    })
+
+    // Act
+    await gitDirectoryHelper.prepareExistingDirectory(
+      git,
+      repositoryPath,
+      repositoryUrl,
+      clean,
+      ref,
+      true // preserveLocalChanges = true
+    )
+
+    // Assert
+    const files = await fs.promises.readdir(repositoryPath)
+    expect(files.sort()).toEqual(['.git', 'my-file']) // Expect both .git and user files to remain
     expect(git.tryClean).toHaveBeenCalled()
     expect(git.tryReset).toHaveBeenCalled()
     expect(core.warning).toHaveBeenCalled()

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,10 @@ inputs:
     description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
   clean:
     description: 'Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching'
-    default: true
+    default: 'true'
+  preserveLocalChanges:
+    description: 'Whether to preserve local changes during checkout. If true, tries to preserve local files that are not tracked by Git. By default, all files will be overwritten.'
+    default: 'false'
   filter:
     description: >
       Partially clone against a given filter.

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ inputs:
   clean:
     description: 'Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching'
     default: 'true'
-  preserveLocalChanges:
+  preserve-local-changes:
     description: 'Whether to preserve local changes during checkout. If true, tries to preserve local files that are not tracked by Git. By default, all files will be overwritten.'
     default: 'false'
   filter:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1141,7 +1141,9 @@ function prepareExistingDirectory(git_1, repositoryPath_1, repositoryUrl_1, clea
             // We still need to make sure we have a git repository to work with
             if (!git) {
                 core.info(`Initializing git repository to prepare for checkout with preserved changes`);
-                yield fs.promises.mkdir(path.join(repositoryPath, '.git'), { recursive: true });
+                yield fs.promises.mkdir(path.join(repositoryPath, '.git'), {
+                    recursive: true
+                });
             }
         }
     });
@@ -1888,7 +1890,9 @@ function getInputs() {
         result.clean = (core.getInput('clean') || 'true').toUpperCase() === 'TRUE';
         core.debug(`clean = ${result.clean}`);
         // Preserve local changes
-        result.preserveLocalChanges = (core.getInput('preserve-local-changes') || 'false').toUpperCase() === 'TRUE';
+        result.preserveLocalChanges =
+            (core.getInput('preserve-local-changes') || 'false').toUpperCase() ===
+                'TRUE';
         core.debug(`preserveLocalChanges = ${result.preserveLocalChanges}`);
         // Filter
         const filter = core.getInput('filter');

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -22,7 +22,7 @@ export interface IGitCommandManager {
   disableSparseCheckout(): Promise<void>
   sparseCheckout(sparseCheckout: string[]): Promise<void>
   sparseCheckoutNonConeMode(sparseCheckout: string[]): Promise<void>
-  checkout(ref: string, startPoint: string): Promise<void>
+  checkout(ref: string, startPoint: string, options?: string[]): Promise<void>
   checkoutDetach(): Promise<void>
   config(
     configKey: string,
@@ -203,8 +203,21 @@ class GitCommandManager {
     )
   }
 
-  async checkout(ref: string, startPoint: string): Promise<void> {
-    const args = ['checkout', '--progress', '--force']
+  async checkout(
+    ref: string,
+    startPoint: string,
+    options: string[] = []
+  ): Promise<void> {
+    const args = ['checkout', '--progress']
+    
+    // Add custom options (like --merge) if provided
+    if (options.length > 0) {
+      args.push(...options)
+    } else {
+      // Default behavior - use force
+      args.push('--force')
+    }
+    
     if (startPoint) {
       args.push('-B', ref, startPoint)
     } else {

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -209,7 +209,7 @@ class GitCommandManager {
     options: string[] = []
   ): Promise<void> {
     const args = ['checkout', '--progress']
-    
+
     // Add custom options (like --merge) if provided
     if (options.length > 0) {
       args.push(...options)
@@ -217,7 +217,7 @@ class GitCommandManager {
       // Default behavior - use force
       args.push('--force')
     }
-    
+
     if (startPoint) {
       args.push('-B', ref, startPoint)
     } else {

--- a/src/git-directory-helper.ts
+++ b/src/git-directory-helper.ts
@@ -122,6 +122,20 @@ export async function prepareExistingDirectory(
     }
   }
 
+  // Check repository conditions
+  let isLocalGitRepo = git && fsHelper.directoryExistsSync(path.join(repositoryPath, '.git'));
+  let repoUrl = isLocalGitRepo ? await git?.tryGetFetchUrl() : '';
+  let isSameRepository = repositoryUrl === repoUrl;
+  let differentRepoUrl = !isSameRepository;
+
+  // Repository URL has changed
+  if (differentRepoUrl) {
+    if (preserveLocalChanges) {
+      core.warning(`Repository URL has changed from '${repoUrl}' to '${repositoryUrl}'. Local changes will be preserved as requested.`);
+    }
+    remove = true; // Mark for removal, but actual removal will respect preserveLocalChanges
+  }
+
   if (remove && !preserveLocalChanges) {
     // Delete the contents of the directory. Don't delete the directory itself
     // since it might be the current working directory.

--- a/src/git-directory-helper.ts
+++ b/src/git-directory-helper.ts
@@ -11,13 +11,19 @@ export async function prepareExistingDirectory(
   repositoryPath: string,
   repositoryUrl: string,
   clean: boolean,
-  ref: string
+  ref: string,
+  preserveLocalChanges: boolean = false
 ): Promise<void> {
   assert.ok(repositoryPath, 'Expected repositoryPath to be defined')
   assert.ok(repositoryUrl, 'Expected repositoryUrl to be defined')
 
   // Indicates whether to delete the directory contents
   let remove = false
+  
+  // If preserveLocalChanges is true, log it
+  if (preserveLocalChanges) {
+    core.info(`Preserve local changes is enabled, will attempt to keep local files`)
+  }
 
   // Check whether using git or REST API
   if (!git) {
@@ -114,12 +120,23 @@ export async function prepareExistingDirectory(
     }
   }
 
-  if (remove) {
+  if (remove && !preserveLocalChanges) {
     // Delete the contents of the directory. Don't delete the directory itself
     // since it might be the current working directory.
     core.info(`Deleting the contents of '${repositoryPath}'`)
     for (const file of await fs.promises.readdir(repositoryPath)) {
+      // Skip .git directory as we need it to determine if a file is tracked
+      if (file === '.git') {
+        continue
+      }
       await io.rmRF(path.join(repositoryPath, file))
+    }
+  } else if (remove && preserveLocalChanges) {
+    core.info(`Skipping deletion of directory contents due to preserve-local-changes setting`)
+    // We still need to make sure we have a git repository to work with
+    if (!git) {
+      core.info(`Initializing git repository to prepare for checkout with preserved changes`)
+      await fs.promises.mkdir(path.join(repositoryPath, '.git'), { recursive: true })
     }
   }
 }

--- a/src/git-directory-helper.ts
+++ b/src/git-directory-helper.ts
@@ -19,10 +19,12 @@ export async function prepareExistingDirectory(
 
   // Indicates whether to delete the directory contents
   let remove = false
-  
+
   // If preserveLocalChanges is true, log it
   if (preserveLocalChanges) {
-    core.info(`Preserve local changes is enabled, will attempt to keep local files`)
+    core.info(
+      `Preserve local changes is enabled, will attempt to keep local files`
+    )
   }
 
   // Check whether using git or REST API
@@ -132,11 +134,17 @@ export async function prepareExistingDirectory(
       await io.rmRF(path.join(repositoryPath, file))
     }
   } else if (remove && preserveLocalChanges) {
-    core.info(`Skipping deletion of directory contents due to preserve-local-changes setting`)
+    core.info(
+      `Skipping deletion of directory contents due to preserve-local-changes setting`
+    )
     // We still need to make sure we have a git repository to work with
     if (!git) {
-      core.info(`Initializing git repository to prepare for checkout with preserved changes`)
-      await fs.promises.mkdir(path.join(repositoryPath, '.git'), { recursive: true })
+      core.info(
+        `Initializing git repository to prepare for checkout with preserved changes`
+      )
+      await fs.promises.mkdir(path.join(repositoryPath, '.git'), {
+        recursive: true
+      })
     }
   }
 }

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -231,9 +231,105 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
     core.startGroup('Checking out the ref')
     if (settings.preserveLocalChanges) {
       core.info('Attempting to preserve local changes during checkout')
-      // Use --merge to preserve local changes if possible
-      // This will fail if there are merge conflicts, but that's expected behavior
-      await git.checkout(checkoutInfo.ref, checkoutInfo.startPoint, ['--merge'])
+      
+      // List and store local files before checkout
+      const fs = require('fs')
+      const path = require('path')
+      const localFiles = new Map()
+      
+      try {
+        // Get all files in the workspace that aren't in the .git directory
+        const workspacePath = process.cwd()
+        core.info(`Current workspace path: ${workspacePath}`)
+        
+        // List all files in the current directory using fs
+        const listFilesRecursively = (dir: string): string[] => {
+          let results: string[] = []
+          const list = fs.readdirSync(dir)
+          list.forEach((file: string) => {
+            const fullPath = path.join(dir, file)
+            const relativePath = path.relative(workspacePath, fullPath)
+            // Skip .git directory
+            if (relativePath.startsWith('.git')) return
+            
+            const stat = fs.statSync(fullPath)
+            if (stat && stat.isDirectory()) {
+              // Recursively explore subdirectories
+              results = results.concat(listFilesRecursively(fullPath))
+            } else {
+              // Store file content in memory
+              try {
+                const content = fs.readFileSync(fullPath)
+                localFiles.set(relativePath, content)
+                results.push(relativePath)
+              } catch (readErr) {
+                core.warning(`Failed to read file ${relativePath}: ${readErr}`)
+              }
+            }
+          })
+          return results
+        }
+        
+        const localFilesList = listFilesRecursively(workspacePath)
+        core.info(`Found ${localFilesList.length} local files to preserve:`)
+        localFilesList.forEach(file => core.info(`  - ${file}`))
+      } catch (error) {
+        core.warning(`Failed to list local files: ${error}`)
+      }
+      
+      // Perform normal checkout
+      await git.checkout(checkoutInfo.ref, checkoutInfo.startPoint)
+      
+      // Restore local files that were not tracked by git
+      core.info('Restoring local files after checkout')
+      try {
+        let restoredCount = 0
+        const execOptions = {
+          cwd: process.cwd(),
+          silent: true,
+          ignoreReturnCode: true
+        }
+        
+        for (const [filePath, content] of localFiles.entries()) {
+          // Check if file exists in git using a child process instead of git.execGit
+          const { exec } = require('@actions/exec')
+          let exitCode = 0
+          const output = {
+            stdout: '',
+            stderr: ''
+          }
+          
+          // Capture output
+          const options = {
+            ...execOptions,
+            listeners: {
+              stdout: (data: Buffer) => {
+                output.stdout += data.toString()
+              },
+              stderr: (data: Buffer) => {
+                output.stderr += data.toString()
+              }
+            }
+          }
+          
+          exitCode = await exec('git', ['ls-files', '--error-unmatch', filePath], options)
+          
+          if (exitCode !== 0) {
+            // File is not tracked by git, safe to restore
+            const fullPath = path.join(process.cwd(), filePath)
+            // Ensure directory exists
+            fs.mkdirSync(path.dirname(fullPath), { recursive: true })
+            fs.writeFileSync(fullPath, content)
+            core.info(`Restored local file: ${filePath}`)
+            restoredCount++
+          } else {
+            core.info(`Skipping ${filePath} as it's tracked by git`)
+          }
+        }
+        core.info(`Successfully restored ${restoredCount} local files`)
+      } catch (error) {
+        core.warning(`Failed to restore local files: ${error}`)
+      }
     } else {
       // Use the default behavior with --force
       await git.checkout(checkoutInfo.ref, checkoutInfo.startPoint)

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -229,7 +229,15 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
 
     // Checkout
     core.startGroup('Checking out the ref')
-    await git.checkout(checkoutInfo.ref, checkoutInfo.startPoint)
+    if (settings.preserveLocalChanges) {
+      core.info('Attempting to preserve local changes during checkout')
+      // Use --merge to preserve local changes if possible
+      // This will fail if there are merge conflicts, but that's expected behavior
+      await git.checkout(checkoutInfo.ref, checkoutInfo.startPoint, ['--merge'])
+    } else {
+      // Use the default behavior with --force
+      await git.checkout(checkoutInfo.ref, checkoutInfo.startPoint)
+    }
     core.endGroup()
 
     // Submodules

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -70,7 +70,8 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
         settings.repositoryPath,
         repositoryUrl,
         settings.clean,
-        settings.ref
+        settings.ref,
+        settings.preserveLocalChanges
       )
     }
 

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -25,9 +25,14 @@ export interface IGitSourceSettings {
   commit: string
 
   /**
-   * Indicates whether to clean the repository
+   * Whether to execute git clean and git reset before fetching
    */
   clean: boolean
+
+  /**
+   * Whether to preserve local changes during checkout
+   */
+  preserveLocalChanges: boolean
 
   /**
    * The filter determining which objects to include

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -83,7 +83,9 @@ export async function getInputs(): Promise<IGitSourceSettings> {
   core.debug(`clean = ${result.clean}`)
 
   // Preserve local changes
-  result.preserveLocalChanges = (core.getInput('preserve-local-changes') || 'false').toUpperCase() === 'TRUE'
+  result.preserveLocalChanges =
+    (core.getInput('preserve-local-changes') || 'false').toUpperCase() ===
+    'TRUE'
   core.debug(`preserveLocalChanges = ${result.preserveLocalChanges}`)
 
   // Filter

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -82,6 +82,10 @@ export async function getInputs(): Promise<IGitSourceSettings> {
   result.clean = (core.getInput('clean') || 'true').toUpperCase() === 'TRUE'
   core.debug(`clean = ${result.clean}`)
 
+  // Preserve local changes
+  result.preserveLocalChanges = (core.getInput('preserveLocalChanges') || 'false').toUpperCase() === 'TRUE'
+  core.debug(`preserveLocalChanges = ${result.preserveLocalChanges}`)
+
   // Filter
   const filter = core.getInput('filter')
   if (filter) {

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -83,7 +83,7 @@ export async function getInputs(): Promise<IGitSourceSettings> {
   core.debug(`clean = ${result.clean}`)
 
   // Preserve local changes
-  result.preserveLocalChanges = (core.getInput('preserveLocalChanges') || 'false').toUpperCase() === 'TRUE'
+  result.preserveLocalChanges = (core.getInput('preserve-local-changes') || 'false').toUpperCase() === 'TRUE'
   core.debug(`preserveLocalChanges = ${result.preserveLocalChanges}`)
 
   // Filter


### PR DESCRIPTION
New option for the GitHub Actions checkout process, allowing users to preserve local files that are not tracked by Git during a checkout. The changes span documentation, configuration, and implementation, ensuring users can opt-in to this behavior via a new `preserve-local-changes` input. The implementation carefully handles file restoration and updates relevant interfaces and workflow examples.

For this https://github.com/actions/checkout/issues/2216 & this https://github.com/actions/checkout/issues/2054

You can test it with this branch/workflow file:

```
name: Test Preserve Local Changes
on:
  workflow_dispatch:

jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - name: Create local file
        shell: bash
        run: |
          echo "This is a test file" > example.txt
          ls -la
          echo "File created successfully"
      
      - name: Checkout
        uses: salmanmkc/checkout@preservelocalchanges
        with:
          clean: false
          preserve-local-changes: true
      
      - name: Verify file exists after checkout
        shell: bash
        run: |
          echo "Checking if example.txt still exists after checkout:"
          if [ -f "example.txt" ]; then
            echo "SUCCESS: File was preserved"
            cat example.txt
          else
            echo "FAILURE: File was removed"
          fi
          
      - name: List all files for debugging
        shell: bash
        run: |
          echo "Listing all files in the directory:"
          ls -la

```