### PR TITLE
Update README to include Node.js 24 support details and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What's new
 
-- Updated to the node24 runtime by default as well as updating checkout to use v5, which uses node24.
+- Updated to the node24 runtime
   - This requires a minimum Actions Runner version of [v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) to run.
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 # Checkout V5
 
-Checkout v5 now supports Node.js 24
+## What's new
+
+- Updated to the node24 runtime by default as well as updating checkout to use v5, which uses node24.
+  - This requires a minimum Actions Runner version of [v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) to run.
+
 
 # Checkout V4
 
@@ -154,9 +158,10 @@ Please refer to the [release page](https://github.com/actions/checkout/releases/
 # Scenarios
 
 - [Checkout V5](#checkout-v5)
+  - [What's new](#whats-new)
 - [Checkout V4](#checkout-v4)
     - [Note](#note)
-- [What's new](#whats-new)
+- [What's new](#whats-new-1)
 - [Usage](#usage)
 - [Scenarios](#scenarios)
   - [Fetch only the root files](#fetch-only-the-root-files)


### PR DESCRIPTION
This pull request updates the documentation to highlight the new default support for Node.js 24 in Checkout v5 and clarifies the minimum Actions Runner version required. This was previously only mentioned in the runner release notes.

To help with https://github.com/actions/checkout/issues/2240