### PR TITLE
Build  for node 24

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2023",
     "module": "commonjs",
     "lib": [
-      "es6"
+      "es2023"
     ],
     "outDir": "./lib",
     "rootDir": "./src",


### PR DESCRIPTION
Now that node24 is the min runtime, we can target a more recent version of ecmascript, and more recent libs.

Now that https://github.com/actions/checkout/pull/2226 is merged, we can rebuild the dist with less shims.