### PR TITLE
Port v6 cleanup to v5

### DIFF
--- a/__test__/git-directory-helper.test.ts
+++ b/__test__/git-directory-helper.test.ts
@@ -499,6 +499,18 @@ async function setup(testName: string): Promise<void> {
       await fs.promises.stat(path.join(repositoryPath, '.git'))
       return repositoryUrl
     }),
+    getSubmoduleConfigPaths: jest.fn(async () => {
+      return []
+    }),
+    tryConfigUnsetValue: jest.fn(async () => {
+      return true
+    }),
+    tryGetConfigValues: jest.fn(async () => {
+      return []
+    }),
+    tryGetConfigKeys: jest.fn(async () => {
+      return []
+    }),
     tryReset: jest.fn(async () => {
       return true
     }),


### PR DESCRIPTION
Auth configuration changed in `actions/checkout@v6-beta`. This PR ports the cleanup for v6-style configuration to v5.

Otherwise, `actions/checkout@v5` will fail if the same repo is already checked out by `actions/checkout@v6-beta`, in the same job, to the same path. Although this scenario is likely very uncommon, I want to reduce friction for users to move to v6.

For quick mitigation if something goes wrong, `ACTIONS_CHECKOUT_SKIP_V6_CLEANUP` can be set to `1` or `true` to skip the new cleanup logic.

<details><summary>Workflow for testing the changes E2E</summary>

```yaml
name: Test Checkout Cleanup

on:
  workflow_dispatch:
  push:
    paths:
      - .github/workflows/test-checkout-cleanup.yml

env:
  ACTIONS_CHECKOUT_SKIP_V6_CLEANUP: true

jobs:
  checkout-v5-then-v6-beta:
    if: false
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v5
        uses: actions/checkout@v5
      
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta

  checkout-v6-beta-then-v5:
    if: false
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
      
      - name: Checkout with v5
        uses: actions/checkout@v5

  checkout-25-11-clean-then-v6-beta:
    if: false
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with 25-11-clean
        uses: actions/checkout@users/ericsciple/25-11-clean
      
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta

  checkout-v6-beta-then-25-11-clean:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
      
      - name: Checkout with 25-11-clean
        uses: actions/checkout@users/ericsciple/25-11-clean

  checkout-v5-then-v6-beta-submodules:
    if: false
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v5
        uses: actions/checkout@v5
        with:
          ref: submodule-test
          submodules: recursive
      
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: recursive

  checkout-v6-beta-then-v5-submodules:
    if: false
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: recursive
      
      - name: Checkout with v5
        uses: actions/checkout@v5
        with:
          ref: submodule-test
          submodules: recursive

  checkout-25-11-clean-then-v6-beta-submodules:
    if: false
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with 25-11-clean
        uses: actions/checkout@users/ericsciple/25-11-clean
        with:
          ref: submodule-test
          submodules: recursive
      
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: recursive

  checkout-v6-beta-then-25-11-clean-submodules:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: recursive
      
      - name: Checkout with 25-11-clean
        uses: actions/checkout@users/ericsciple/25-11-clean
        with:
          ref: submodule-test
          submodules: recursive

  checkout-v5-then-v6-beta-submodules-true:
    if: false
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v5
        uses: actions/checkout@v5
        with:
          ref: submodule-test
          submodules: true
      
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: true

  checkout-v6-beta-then-v5-submodules-true:
    if: false
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: true
      
      - name: Checkout with v5
        uses: actions/checkout@v5
        with:
          ref: submodule-test
          submodules: true

  checkout-25-11-clean-then-v6-beta-submodules-true:
    if: false
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with 25-11-clean
        uses: actions/checkout@users/ericsciple/25-11-clean
        with:
          ref: submodule-test
          submodules: true
      
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: true

  checkout-v6-beta-then-25-11-clean-submodules-true:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: true
      
      - name: Checkout with 25-11-clean
        uses: actions/checkout@users/ericsciple/25-11-clean
        with:
          ref: submodule-test
          submodules: true
```

</details>