### PR TITLE
Update README.md to describe fetching full history of one branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Please refer to the [release page](https://github.com/actions/checkout/releases/
     sparse-checkout-cone-mode: ''
 
     # Number of commits to fetch. 0 indicates all history for all branches and tags.
+    # 2147483647 indicates full history for the single branch being checked out.
     # Default: 1
     fetch-depth: ''
 


### PR DESCRIPTION
Document how to fetch full history for a single branch.

This implies `--single-branch` but infinite depth for that branch.

The magic number is documented at https://git-scm.com/docs/shallow
and a way to do this has been requested several times: #285 #346 #520 