### PR TITLE
Port v6 cleanup to v4

### DIFF
--- a/__test__/git-directory-helper.test.ts
+++ b/__test__/git-directory-helper.test.ts
@@ -499,6 +499,18 @@ async function setup(testName: string): Promise<void> {
       await fs.promises.stat(path.join(repositoryPath, '.git'))
       return repositoryUrl
     }),
+    getSubmoduleConfigPaths: jest.fn(async () => {
+      return []
+    }),
+    tryConfigUnsetValue: jest.fn(async () => {
+      return true
+    }),
+    tryGetConfigValues: jest.fn(async () => {
+      return []
+    }),
+    tryGetConfigKeys: jest.fn(async () => {
+      return []
+    }),
     tryReset: jest.fn(async () => {
       return true
     }),


### PR DESCRIPTION
Auth configuration changed in `actions/checkout@v6-beta`. This PR ports the cleanup for v6-style configuration to v4.

Otherwise, `actions/checkout@v4` will fail if the same repo is already checked out by `actions/checkout@v6-beta`, in the same job, to the same path. Although this scenario is likely very uncommon, I want to reduce friction for users to move to v6.

For quick mitigation if something goes wrong, `ACTIONS_CHECKOUT_SKIP_V6_CLEANUP` can be set to `1` or `true` to skip the new cleanup logic.

<details><summary>Workflow for testing the changes E2E</summary>

```yaml
name: Test Checkout Cleanup

on:
  workflow_dispatch:
  push:
    paths:
      - .github/workflows/test-checkout-cleanup-v4.yml

env:
  ACTIONS_CHECKOUT_SKIP_V6_CLEANUP: true

jobs:
  checkout-v4-then-v6-beta:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v4
        uses: actions/checkout@v4
      
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta

  checkout-v6-beta-then-v4:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
      
      - name: Checkout with v4
        uses: actions/checkout@v4

  checkout-25-11-clean2-then-v6-beta:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with 25-11-clean2
        uses: actions/checkout@users/ericsciple/25-11-clean2
      
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta

  checkout-v6-beta-then-25-11-clean2:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
      
      - name: Checkout with 25-11-clean2
        uses: actions/checkout@users/ericsciple/25-11-clean2

  checkout-v4-then-v6-beta-submodules:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v4
        uses: actions/checkout@v4
        with:
          ref: submodule-test
          submodules: recursive
      
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: recursive

  checkout-v6-beta-then-v4-submodules:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: recursive
      
      - name: Checkout with v4
        uses: actions/checkout@v4
        with:
          ref: submodule-test
          submodules: recursive

  checkout-25-11-clean2-then-v6-beta-submodules:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with 25-11-clean2
        uses: actions/checkout@users/ericsciple/25-11-clean2
        with:
          ref: submodule-test
          submodules: recursive
      
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: recursive

  checkout-v6-beta-then-25-11-clean2-submodules:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: recursive
      
      - name: Checkout with 25-11-clean2
        uses: actions/checkout@users/ericsciple/25-11-clean2
        with:
          ref: submodule-test
          submodules: recursive

  checkout-v4-then-v6-beta-submodules-true:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v4
        uses: actions/checkout@v4
        with:
          ref: submodule-test
          submodules: true
      
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: true

  checkout-v6-beta-then-v4-submodules-true:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: true
      
      - name: Checkout with v4
        uses: actions/checkout@v4
        with:
          ref: submodule-test
          submodules: true

  checkout-25-11-clean2-then-v6-beta-submodules-true:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with 25-11-clean2
        uses: actions/checkout@users/ericsciple/25-11-clean2
        with:
          ref: submodule-test
          submodules: true
      
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: true

  checkout-v6-beta-then-25-11-clean2-submodules-true:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout with v6-beta
        uses: actions/checkout@v6-beta
        with:
          ref: submodule-test
          submodules: true
      
      - name: Checkout with 25-11-clean2
        uses: actions/checkout@users/ericsciple/25-11-clean2
        with:
          ref: submodule-test
          submodules: true
```

</details>

Related PRs:
- https://github.com/actions/checkout/pull/2286
- https://github.com/actions/checkout/pull/2301