### PR TITLE
Use realpath when including persisted credentials

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,6 +181,25 @@ jobs:
         with:
           args: bash __test__/verify-worktree.sh worktree-test container-worktree-branch
 
+      # Credentials when checkout out into symlink
+      - name: Setup for symlink test
+        run: mkdir symlink-test-real && ln -s symlink-test-real symlink-test-link
+      - name: Checkout for worktree test
+        uses: ./
+        with:
+          path: symlink-test-link
+      - name: Verify symlink credentials
+        run: |
+          cd symlink-test-real
+          if git config --list --show-origin | grep -q "extraheader"; then
+            echo "Credentials are configured"
+          else
+            echo "ERROR: Credentials are NOT configured"
+            echo "Full git config:"
+            git config --list --show-origin
+            exit 1
+          fi
+
       # Basic checkout using REST API
       - name: Remove basic
         if: runner.os != 'windows'

--- a/dist/index.js
+++ b/dist/index.js
@@ -407,7 +407,7 @@ class GitAuthHelper {
             }
             else {
                 // Host git directory
-                let gitDir = path.join(this.git.getWorkingDirectory(), '.git');
+                let gitDir = fs.realpathSync(path.join(this.git.getWorkingDirectory(), '.git'));
                 gitDir = gitDir.replace(/\\/g, '/'); // Use forward slashes, even on Windows
                 // Configure host includeIf
                 const hostIncludeKey = `includeIf.gitdir:${gitDir}.path`;

--- a/dist/index.js
+++ b/dist/index.js
@@ -267,7 +267,7 @@ class GitAuthHelper {
                 // Configure both host and container paths to support Docker container actions.
                 for (const configPath of configPaths) {
                     // Submodule Git directory
-                    let submoduleGitDir = path.dirname(configPath); // The config file is at .git/modules/submodule-name/config
+                    let submoduleGitDir = yield fs.promises.realpath(path.dirname(configPath)); // The config file is at .git/modules/submodule-name/config
                     submoduleGitDir = submoduleGitDir.replace(/\\/g, '/'); // Use forward slashes, even on Windows
                     // Configure host includeIf
                     yield this.git.config(`includeIf.gitdir:${submoduleGitDir}.path`, credentialsConfigPath, false, // globalConfig?
@@ -407,7 +407,7 @@ class GitAuthHelper {
             }
             else {
                 // Host git directory
-                let gitDir = fs.realpathSync(path.join(this.git.getWorkingDirectory(), '.git'));
+                let gitDir = yield fs.promises.realpath(path.join(this.git.getWorkingDirectory(), '.git'));
                 gitDir = gitDir.replace(/\\/g, '/'); // Use forward slashes, even on Windows
                 // Configure host includeIf
                 const hostIncludeKey = `includeIf.gitdir:${gitDir}.path`;

--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -177,7 +177,9 @@ class GitAuthHelper {
       // Configure both host and container paths to support Docker container actions.
       for (const configPath of configPaths) {
         // Submodule Git directory
-        let submoduleGitDir = path.dirname(configPath) // The config file is at .git/modules/submodule-name/config
+        let submoduleGitDir = await fs.promises.realpath(
+          path.dirname(configPath)
+        ) // The config file is at .git/modules/submodule-name/config
         submoduleGitDir = submoduleGitDir.replace(/\\/g, '/') // Use forward slashes, even on Windows
 
         // Configure host includeIf
@@ -367,7 +369,7 @@ class GitAuthHelper {
       )
     } else {
       // Host git directory
-      let gitDir = fs.realpathSync(
+      let gitDir = await fs.promises.realpath(
         path.join(this.git.getWorkingDirectory(), '.git')
       )
       gitDir = gitDir.replace(/\\/g, '/') // Use forward slashes, even on Windows

--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -367,7 +367,7 @@ class GitAuthHelper {
       )
     } else {
       // Host git directory
-      let gitDir = path.join(this.git.getWorkingDirectory(), '.git')
+      let gitDir = fs.realpathSync(path.join(this.git.getWorkingDirectory(), '.git'))
       gitDir = gitDir.replace(/\\/g, '/') // Use forward slashes, even on Windows
 
       // Configure host includeIf

--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -367,7 +367,9 @@ class GitAuthHelper {
       )
     } else {
       // Host git directory
-      let gitDir = fs.realpathSync(path.join(this.git.getWorkingDirectory(), '.git'))
+      let gitDir = fs.realpathSync(
+        path.join(this.git.getWorkingDirectory(), '.git')
+      )
       gitDir = gitDir.replace(/\\/g, '/') // Use forward slashes, even on Windows
 
       // Configure host includeIf


### PR DESCRIPTION
This uses the realpath of the git working directory when configuring credentials so that if the checkout is into a symlink, `git` when in the real path still includes them.

I ran into this as an issue on a self-hosted macOS runner whose working directory was under `/var`. On macOS `/var` is a symlink to `/private/var`, so when actions/checkout was configuring credentials it was using the symlink path, which was causing the `includeIf.gitdir` check to fail.