### PR TITLE
Add path output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -334,6 +334,7 @@ jobs:
         run: |
           echo "Commit: ${{ steps.checkout.outputs.commit }}"
           echo "Ref: ${{ steps.checkout.outputs.ref }}"
+          echo "Path: ${{ steps.checkout.outputs.path }}"
 
           if [ "${{ steps.checkout.outputs.ref }}" != "test-data/v2/basic" ]; then
             echo "Expected ref to be test-data/v2/basic"
@@ -342,5 +343,10 @@ jobs:
 
           if [ "${{ steps.checkout.outputs.commit }}" != "82f71901cf8c021332310dcc8cdba84c4193ff5d" ]; then
             echo "Expected commit to be 82f71901cf8c021332310dcc8cdba84c4193ff5d"
+            exit 1
+          fi
+
+          if [[ "${{ steps.checkout.outputs.path }}" != *"/cloned-using-local-action" ]]; then
+            echo "Expected path to end with /cloned-using-local-action"
             exit 1
           fi

--- a/action.yml
+++ b/action.yml
@@ -103,6 +103,8 @@ outputs:
     description: 'The branch, tag or SHA that was checked out'
   commit:
     description: 'The commit SHA that was checked out'
+  path:
+    description: 'The absolute path that was checked out to'
 runs:
   using: node24
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -2135,6 +2135,7 @@ function run() {
                 // Get sources
                 yield gitSourceProvider.getSource(sourceSettings);
                 core.setOutput('ref', sourceSettings.ref);
+                core.setOutput('path', sourceSettings.repositoryPath);
             }
             finally {
                 // Unregister problem matcher

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ async function run(): Promise<void> {
       // Get sources
       await gitSourceProvider.getSource(sourceSettings)
       core.setOutput('ref', sourceSettings.ref)
+      core.setOutput('path', sourceSettings.repositoryPath)
     } finally {
       // Unregister problem matcher
       coreCommand.issueCommand('remove-matcher', {owner: 'checkout-git'}, '')


### PR DESCRIPTION
Adds an output for `path`.

Similar to https://github.com/actions/checkout/pull/1180, which added outputs for `ref` and `commit`.

Having the checkout path available as an output is especially useful when using the `path` input, and avoids having to duplicate the path manually.

Example:

```diff
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout content
         id: content
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: mdn/content
           path: mdn/content
           persist-credentials: false

       - name: Run fred
-        working-directory: mdn/content
+        working-directory: ${{ steps.content.outputs.path }}
         env:
-          CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
+          CONTENT_ROOT: ${{ steps.content.outputs.path }}/files
         run: npm start
```