### PR TITLE
fix: Add missing step id for artifact upload condition

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -36,6 +36,7 @@ jobs:
         run: npm run build
 
       - name: Compare the expected and actual dist/ directories
+        id: diff
         run: |
           if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
             echo "Detected uncommitted changes after build.  See status below:"


### PR DESCRIPTION
The artifact upload step references `steps.diff.conclusion` but the step doesn't have `id: diff` defined. This might cause the condition to never evaluate to true.

If this is intentional, please feel free to ignore this PR.