### PR TITLE
Also rewrite `ssh://` URLs

### DIFF
--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -66,6 +66,7 @@ class GitAuthHelper {
     // Instead of SSH URL
     this.insteadOfKey = `url.${serverUrl.origin}/.insteadOf` // "origin" is SCHEME://HOSTNAME[:PORT]
     this.insteadOfValues.push(`git@${serverUrl.hostname}:`)
+    this.insteadOfValues.push(`ssh://git@${serverUrl.hostname}/`)
     if (this.settings.workflowOrganizationId) {
       this.insteadOfValues.push(
         `org-${this.settings.workflowOrganizationId}@github.com:`


### PR DESCRIPTION
Like `git@server:` remotes, also rewrite `ssh://git@server/`

Closes: #2178