### PR TITLE
Suppress verbose `git checkout --detached` output with --quiet

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Please refer to the [release page](https://github.com/actions/checkout/releases/
     # Default: false
     fetch-tags: ''
 
-    # Whether to show progress status output when fetching.
+    # Whether to show progress status output for git operations.
     # Default: true
     show-progress: ''
 

--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,7 @@ inputs:
     description: 'Whether to fetch tags, even if fetch-depth > 0.'
     default: false
   show-progress:
-    description: 'Whether to show progress status output when fetching.'
+    description: 'Whether to show progress status output for git operations.'
     default: true
   lfs:
     description: 'Whether to download Git-LFS files'

--- a/dist/index.js
+++ b/dist/index.js
@@ -780,9 +780,9 @@ class GitCommandManager {
             yield fs.promises.appendFile(sparseCheckoutPath, `\n${sparseCheckout.join('\n')}\n`);
         });
     }
-    checkout(ref, startPoint) {
+    checkout(ref, startPoint, showProgress) {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['checkout', '--progress', '--force'];
+            const args = ['checkout', showProgress ? '--progress' : '--quiet', '--force'];
             if (startPoint) {
                 args.push('-B', ref, startPoint);
             }
@@ -792,9 +792,9 @@ class GitCommandManager {
             yield this.execGit(args);
         });
     }
-    checkoutDetach() {
+    checkoutDetach(showProgress) {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['checkout', '--detach'];
+            const args = ['checkout', '--detach', showProgress ? '--progress' : '--quiet'];
             yield this.execGit(args);
         });
     }
@@ -1523,6 +1523,9 @@ function getSource(settings) {
             // Fetch
             core.startGroup('Fetching the repository');
             const fetchOptions = {};
+            if (settings.showProgress) {
+                fetchOptions.showProgress = true;
+            }
             if (settings.filter) {
                 fetchOptions.filter = settings.filter;
             }
@@ -1593,7 +1596,7 @@ function getSource(settings) {
             }
             // Checkout
             core.startGroup('Checking out the ref');
-            yield git.checkout(checkoutInfo.ref, checkoutInfo.startPoint);
+            yield git.checkout(checkoutInfo.ref, checkoutInfo.startPoint, settings.showProgress);
             core.endGroup();
             // Submodules
             if (settings.submodules) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1310,7 +1310,7 @@ function prepareExistingDirectory(git, repositoryPath, repositoryUrl, clean, ref
                 core.startGroup('Removing previously created refs, to avoid conflicts');
                 // Checkout detached HEAD
                 if (!(yield git.isDetached())) {
-                    yield git.checkoutDetach();
+                    yield git.checkoutDetach(false);
                 }
                 // Remove all refs/heads/*
                 let branches = yield git.branchList(false);

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -22,8 +22,8 @@ export interface IGitCommandManager {
   disableSparseCheckout(): Promise<void>
   sparseCheckout(sparseCheckout: string[]): Promise<void>
   sparseCheckoutNonConeMode(sparseCheckout: string[]): Promise<void>
-  checkout(ref: string, startPoint: string): Promise<void>
-  checkoutDetach(): Promise<void>
+  checkout(ref: string, startPoint: string, showProgress?: boolean): Promise<void>
+  checkoutDetach(showProgress?: boolean): Promise<void>
   config(
     configKey: string,
     configValue: string,
@@ -220,8 +220,8 @@ class GitCommandManager {
     )
   }
 
-  async checkout(ref: string, startPoint: string): Promise<void> {
-    const args = ['checkout', '--quiet', '--force']
+  async checkout(ref: string, startPoint: string, showProgress?: boolean): Promise<void> {
+    const args = ['checkout', showProgress ? '--progress' : '--quiet', '--force']
     if (startPoint) {
       args.push('-B', ref, startPoint)
     } else {
@@ -231,8 +231,8 @@ class GitCommandManager {
     await this.execGit(args)
   }
 
-  async checkoutDetach(): Promise<void> {
-    const args = ['checkout', '--detach', '--quiet']
+  async checkoutDetach(showProgress?: boolean): Promise<void> {
+    const args = ['checkout', '--detach', showProgress ? '--progress' : '--quiet']
     await this.execGit(args)
   }
 

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -22,8 +22,8 @@ export interface IGitCommandManager {
   disableSparseCheckout(): Promise<void>
   sparseCheckout(sparseCheckout: string[]): Promise<void>
   sparseCheckoutNonConeMode(sparseCheckout: string[]): Promise<void>
-  checkout(ref: string, startPoint: string, showProgress?: boolean): Promise<void>
-  checkoutDetach(showProgress?: boolean): Promise<void>
+  checkout(ref: string, startPoint: string, showProgress: boolean): Promise<void>
+  checkoutDetach(showProgress: boolean): Promise<void>
   config(
     configKey: string,
     configValue: string,
@@ -220,7 +220,7 @@ class GitCommandManager {
     )
   }
 
-  async checkout(ref: string, startPoint: string, showProgress?: boolean): Promise<void> {
+  async checkout(ref: string, startPoint: string, showProgress: boolean): Promise<void> {
     const args = ['checkout', showProgress ? '--progress' : '--quiet', '--force']
     if (startPoint) {
       args.push('-B', ref, startPoint)
@@ -231,7 +231,7 @@ class GitCommandManager {
     await this.execGit(args)
   }
 
-  async checkoutDetach(showProgress?: boolean): Promise<void> {
+  async checkoutDetach(showProgress: boolean): Promise<void> {
     const args = ['checkout', '--detach', showProgress ? '--progress' : '--quiet']
     await this.execGit(args)
   }

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -221,7 +221,7 @@ class GitCommandManager {
   }
 
   async checkout(ref: string, startPoint: string): Promise<void> {
-    const args = ['checkout', '--progress', '--force']
+    const args = ['checkout', '--quiet', '--force']
     if (startPoint) {
       args.push('-B', ref, startPoint)
     } else {
@@ -232,7 +232,7 @@ class GitCommandManager {
   }
 
   async checkoutDetach(): Promise<void> {
-    const args = ['checkout', '--detach']
+    const args = ['checkout', '--detach', '--quiet']
     await this.execGit(args)
   }
 

--- a/src/git-directory-helper.ts
+++ b/src/git-directory-helper.ts
@@ -49,7 +49,7 @@ export async function prepareExistingDirectory(
       core.startGroup('Removing previously created refs, to avoid conflicts')
       // Checkout detached HEAD
       if (!(await git.isDetached())) {
-        await git.checkoutDetach()
+        await git.checkoutDetach(false)
       }
 
       // Remove all refs/heads/*

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -162,6 +162,10 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
       showProgress?: boolean
     } = {}
 
+    if (settings.showProgress) {
+      fetchOptions.showProgress = true
+    }
+
     if (settings.filter) {
       fetchOptions.filter = settings.filter
     } else if (settings.sparseCheckout) {
@@ -251,7 +255,7 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
 
     // Checkout
     core.startGroup('Checking out the ref')
-    await git.checkout(checkoutInfo.ref, checkoutInfo.startPoint)
+    await git.checkout(checkoutInfo.ref, checkoutInfo.startPoint, settings.showProgress)
     core.endGroup()
 
     // Submodules

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -55,7 +55,8 @@ export interface IGitSourceSettings {
   fetchTags: boolean
 
   /**
-   * Indicates whether to use the --progress option when fetching
+   * Indicates whether to show progress status output for git operations.
+   * When false, git commands use --quiet to suppress verbose output.
    */
   showProgress: boolean
 


### PR DESCRIPTION
## Summary

When `actions/checkout` runs against a large repository, `git checkout --detach` outputs every file being written to the log. 

<img width="558" height="187" alt="image" src="https://github.com/user-attachments/assets/c81e98d1-af05-47e1-9a29-838fb67132b3" />

<img width="218" height="57" alt="image" src="https://github.com/user-attachments/assets/c0328451-adec-42bd-9064-5edeed10367a" />


For repos with thousands of files this floods the GitHub Actions log. For our repo this was something like 80k log lines. Why does this matter? Because when Agents read Github Actions logs (which are already chatty) they can easily consume 80k lines of noise for no reason. There are methods for avoiding that, but this output also seems low-value as-is.

In this PR:

I initially was just going to target `checkoutDetach` but then realized there was an existing `progress` config. I figured maybe a more holistic approach would be to reuse this concept. So I have:

- Replaced `--progress` with `--quiet` in `checkout()` to suppress per-file output during checkout
- Add `--quiet` to `checkoutDetach()` for the same reason
- Thread `showProgress` through `checkout()` and `checkoutDetach()` so callers can still opt into `--progress` output; default remains `--quiet`
- Fix `fetchOptions.showProgress` not being set in `git-source-provider.ts` (was always `undefined`, so `--progress` was never applied to fetch either)
- Broaden `show-progress` description from fetch-specific to all git operations

Users can set `show-progress: true` (the default) to keep verbose output, or `show-progress: false` to quiet all git operations.

## **Alternatively, can keep this very directly constrained to the detached checkout**

(note to self, do not rebase this branch as we are referencing it a specific commit in it already)