### PR TITLE
Enable sparse index to fix Git LFS performance with sparse checkouts

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -645,7 +645,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.MinimumGitSparseCheckoutVersion = exports.MinimumGitVersion = void 0;
+exports.MinimumGitSparseIndexVersion = exports.MinimumGitSparseCheckoutVersion = exports.MinimumGitVersion = void 0;
 exports.createCommandManager = createCommandManager;
 const core = __importStar(__nccwpck_require__(2186));
 const exec = __importStar(__nccwpck_require__(1514));
@@ -661,6 +661,7 @@ const git_version_1 = __nccwpck_require__(3142);
 // sparse-checkout not [well-]supported before 2.28 (see https://github.com/actions/checkout/issues/1386)
 exports.MinimumGitVersion = new git_version_1.GitVersion('2.18');
 exports.MinimumGitSparseCheckoutVersion = new git_version_1.GitVersion('2.28');
+exports.MinimumGitSparseIndexVersion = new git_version_1.GitVersion('2.32');
 function createCommandManager(workingDirectory, lfs, doSparseCheckout) {
     return __awaiter(this, void 0, void 0, function* () {
         return yield GitCommandManager.createCommandManager(workingDirectory, lfs, doSparseCheckout);
@@ -1573,9 +1574,9 @@ function getSource(settings) {
                 yield git.lfsFetch(checkoutInfo.startPoint || checkoutInfo.ref);
                 core.endGroup();
             }
+            let gitVersion = yield git.version();
             // Sparse checkout
             if (!settings.sparseCheckout) {
-                let gitVersion = yield git.version();
                 // no need to disable sparse-checkout if the installed git runtime doesn't even support it.
                 if (gitVersion.checkMinimum(git_command_manager_1.MinimumGitSparseCheckoutVersion)) {
                     yield git.disableSparseCheckout();
@@ -1588,6 +1589,9 @@ function getSource(settings) {
                 }
                 else {
                     yield git.sparseCheckoutNonConeMode(settings.sparseCheckout);
+                }
+                if (gitVersion.checkMinimum(git_command_manager_1.MinimumGitSparseIndexVersion)) {
+                    yield git.config('index.sparse', 'true', false);
                 }
                 core.endGroup();
             }

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -14,6 +14,7 @@ import {GitVersion} from './git-version'
 // sparse-checkout not [well-]supported before 2.28 (see https://github.com/actions/checkout/issues/1386)
 export const MinimumGitVersion = new GitVersion('2.18')
 export const MinimumGitSparseCheckoutVersion = new GitVersion('2.28')
+export const MinimumGitSparseIndexVersion = new GitVersion('2.32')
 
 export interface IGitCommandManager {
   branchDelete(remote: boolean, branch: string): Promise<void>

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -11,6 +11,7 @@ import * as stateHelper from './state-helper'
 import * as urlHelper from './url-helper'
 import {
   MinimumGitSparseCheckoutVersion,
+  MinimumGitSparseIndexVersion,
   IGitCommandManager
 } from './git-command-manager'
 import {IGitSourceSettings} from './git-source-settings'
@@ -232,9 +233,9 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
       core.endGroup()
     }
 
+    let gitVersion = await git.version()
     // Sparse checkout
     if (!settings.sparseCheckout) {
-      let gitVersion = await git.version()
       // no need to disable sparse-checkout if the installed git runtime doesn't even support it.
       if (gitVersion.checkMinimum(MinimumGitSparseCheckoutVersion)) {
         await git.disableSparseCheckout()
@@ -245,6 +246,10 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
         await git.sparseCheckout(settings.sparseCheckout)
       } else {
         await git.sparseCheckoutNonConeMode(settings.sparseCheckout)
+      }
+
+      if (gitVersion.checkMinimum(MinimumGitSparseIndexVersion)) {
+        await git.config('index.sparse', 'true', false)
       }
       core.endGroup()
     }


### PR DESCRIPTION
If you have LFS in the repo, enabling sparse checkouts is catastrophic for LFS performance due to LFS slowly enumerating every file in the repo one-by-one ignoring sparse-checkout filters and LFS own --include.
This is fixed by enabling sparse index, which is pretty much a requirement for git-lfs compatibility with sparse checkout, see git-lfs/git-lfs#5796
Checking for settings.lfs doesn't quite work here as lfs might be disabled during the initial checkout and accessed later in scripts (actually that's our case).