### PR TITLE
fix: handle Forgejo instances at subpaths

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2731,7 +2731,8 @@ function getFetchUrl(settings) {
         return `${user}@${serviceUrl.hostname}:${encodedOwner}/${encodedName}.git`;
     }
     // "origin" is SCHEME://HOSTNAME[:PORT]
-    return `${serviceUrl.origin}/${encodedOwner}/${encodedName}`;
+    const rootUrl = serviceUrl.origin + serviceUrl.pathname.replace(/\/$/, '');
+    return `${rootUrl}/${encodedOwner}/${encodedName}`;
 }
 function getServerUrl(url) {
     let resolvedUrl = process.env['GITHUB_SERVER_URL'] || 'https://github.com';

--- a/src/url-helper.ts
+++ b/src/url-helper.ts
@@ -17,7 +17,8 @@ export function getFetchUrl(settings: IGitSourceSettings): string {
   }
 
   // "origin" is SCHEME://HOSTNAME[:PORT]
-  return `${serviceUrl.origin}/${encodedOwner}/${encodedName}`
+  const rootUrl = serviceUrl.origin + serviceUrl.pathname.replace(/\/$/, '')
+  return `${rootUrl}/${encodedOwner}/${encodedName}`
 }
 
 export function getServerUrl(url?: string): URL {


### PR DESCRIPTION
https://code.forgejo.org/actions/checkout is a read only mirror, not a fork, of this repository, so I'm making my pull request here. I understand if you reject it purely because you don't care about Forgejo, but it's a tiny change and would be nice if you merged it, pretty please!

Without this change, the action fails if Forgejo or GitHub is hosted at, for example, `https://github.com/subpath/`