### PR TITLE
fix: expand SHA regex to support SHA-256 (64-char) commit hashes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2021,7 +2021,7 @@ function getInputs() {
             }
         }
         // SHA?
-        else if (result.ref.match(/^[0-9a-fA-F]{40}$/)) {
+        else if (result.ref.match(/^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/)) {
             result.commit = result.ref;
             result.ref = '';
         }

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -71,7 +71,7 @@ export async function getInputs(): Promise<IGitSourceSettings> {
     }
   }
   // SHA?
-  else if (result.ref.match(/^[0-9a-fA-F]{40}$/)) {
+  else if (result.ref.match(/^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/)) {
     result.commit = result.ref
     result.ref = ''
   }


### PR DESCRIPTION
## Summary
Update `input-helper.ts` to recognize both 40-char (SHA-1) and 64-char (SHA-256) hex strings as commit SHAs. Rebuild `dist/index.js`.

## Changes
- **`src/input-helper.ts`**: Update regex from `/^[0-9a-fA-F]{40}$/` to `/^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/`
- **`dist/index.js`**: Rebuilt bundle

## Validation
- Build passes (`npm run build`)
- 8 test suites, 96 tests pass (`npm test`)

## Context
- Parent epic: SHA-256 Support for Git Repositories

---
*Automated by `project-board-agents-plugin` via `/project-board-agents:lead`*
*Board: https://github.com/orgs/github/projects/24272/views/1*
*Item: [P0] Fix SHA-1 regex in actions/checkout input-helper.ts*
*Run: sha256-p0-checkout-00050*