### PR TITLE
fix: expand merge commit SHA regex and add SHA-256 test cases

### DIFF
--- a/__test__/input-helper.test.ts
+++ b/__test__/input-helper.test.ts
@@ -134,7 +134,8 @@ describe('input-helper tests', () => {
   })
 
   it('sets ref to empty when explicit sha-256', async () => {
-    inputs.ref = '1111111111222222222233333333334444444444555555555566666666667777'
+    inputs.ref =
+      '1111111111222222222233333333334444444444555555555566666666667777'
     const settings: IGitSourceSettings = await inputHelper.getInputs()
     expect(settings.ref).toBeFalsy()
     expect(settings.commit).toBe(

--- a/__test__/input-helper.test.ts
+++ b/__test__/input-helper.test.ts
@@ -133,6 +133,15 @@ describe('input-helper tests', () => {
     expect(settings.commit).toBe('1111111111222222222233333333334444444444')
   })
 
+  it('sets ref to empty when explicit sha-256', async () => {
+    inputs.ref = '1111111111222222222233333333334444444444555555555566666666667777'
+    const settings: IGitSourceSettings = await inputHelper.getInputs()
+    expect(settings.ref).toBeFalsy()
+    expect(settings.commit).toBe(
+      '1111111111222222222233333333334444444444555555555566666666667777'
+    )
+  })
+
   it('sets sha to empty when explicit ref', async () => {
     inputs.ref = 'refs/heads/some-other-ref'
     const settings: IGitSourceSettings = await inputHelper.getInputs()

--- a/__test__/ref-helper.test.ts
+++ b/__test__/ref-helper.test.ts
@@ -1,4 +1,6 @@
 import * as assert from 'assert'
+import * as core from '@actions/core'
+import * as github from '@actions/github'
 import * as refHelper from '../lib/ref-helper'
 import {IGitCommandManager} from '../lib/git-command-manager'
 
@@ -234,5 +236,143 @@ describe('ref-helper tests', () => {
     expect(refSpec[1]).toBe(
       '+refs/heads/my/branch:refs/remotes/origin/my/branch'
     )
+  })
+
+  describe('checkCommitInfo', () => {
+    const repositoryOwner = 'some-owner'
+    const repositoryName = 'some-repo'
+    const ref = 'refs/pull/123/merge'
+    const sha1Head = '1111111111222222222233333333334444444444'
+    const sha1Base = 'aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd'
+    const sha256Head =
+      '1111111111222222222233333333334444444444555555555566666666667777'
+    const sha256Base =
+      'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff0000'
+    let debugSpy: jest.SpyInstance
+    let getOctokitSpy: jest.SpyInstance
+    let repoGetSpy: jest.Mock
+    let originalEventName: string
+    let originalPayload: unknown
+    let originalRef: string
+    let originalSha: string
+
+    function setPullRequestContext(
+      expectedHeadSha: string,
+      expectedBaseSha: string,
+      mergeCommit: string
+    ): void {
+      ;(github.context as any).eventName = 'pull_request'
+      github.context.ref = ref
+      github.context.sha = mergeCommit
+      ;(github.context as any).payload = {
+        action: 'synchronize',
+        after: expectedHeadSha,
+        number: 123,
+        pull_request: {
+          base: {
+            sha: expectedBaseSha
+          }
+        },
+        repository: {
+          private: false
+        }
+      }
+    }
+
+    beforeEach(() => {
+      originalEventName = github.context.eventName
+      originalPayload = github.context.payload
+      originalRef = github.context.ref
+      originalSha = github.context.sha
+
+      jest.spyOn(github.context, 'repo', 'get').mockReturnValue({
+        owner: repositoryOwner,
+        repo: repositoryName
+      })
+      debugSpy = jest.spyOn(core, 'debug').mockImplementation(jest.fn())
+      repoGetSpy = jest.fn(async () => ({}))
+      getOctokitSpy = jest.spyOn(github, 'getOctokit').mockReturnValue({
+        rest: {
+          repos: {
+            get: repoGetSpy
+          }
+        }
+      } as any)
+    })
+
+    afterEach(() => {
+      ;(github.context as any).eventName = originalEventName
+      ;(github.context as any).payload = originalPayload
+      github.context.ref = originalRef
+      github.context.sha = originalSha
+      jest.restoreAllMocks()
+    })
+
+    it('returns early for SHA-1 merge commit', async () => {
+      setPullRequestContext(sha1Head, sha1Base, commit)
+
+      await refHelper.checkCommitInfo(
+        'token',
+        `Merge ${sha1Head} into ${sha1Base}`,
+        repositoryOwner,
+        repositoryName,
+        ref,
+        commit
+      )
+
+      expect(getOctokitSpy).not.toHaveBeenCalled()
+      expect(repoGetSpy).not.toHaveBeenCalled()
+    })
+
+    it('matches SHA-256 merge commit info', async () => {
+      const actualHeadSha =
+        '9999999999888888888877777777776666666666555555555544444444443333'
+      setPullRequestContext(sha256Head, sha256Base, sha256Commit)
+
+      await refHelper.checkCommitInfo(
+        'token',
+        `Merge ${actualHeadSha} into ${sha256Base}`,
+        repositoryOwner,
+        repositoryName,
+        ref,
+        sha256Commit
+      )
+
+      expect(getOctokitSpy).toHaveBeenCalledWith(
+        'token',
+        expect.objectContaining({
+          userAgent: expect.stringContaining(
+            `expected_head_sha=${sha256Head};actual_head_sha=${actualHeadSha}`
+          )
+        })
+      )
+      expect(repoGetSpy).toHaveBeenCalledWith({
+        owner: repositoryOwner,
+        repo: repositoryName
+      })
+      expect(debugSpy).toHaveBeenCalledWith(
+        `Expected head sha ${sha256Head}; actual head sha ${actualHeadSha}`
+      )
+      expect(debugSpy).not.toHaveBeenCalledWith('Unexpected message format')
+    })
+
+    it('does not match 50-char hex as a valid merge', async () => {
+      const invalidHeadSha =
+        '99999999998888888888777777777766666666665555555555'
+      setPullRequestContext(sha1Head, sha1Base, commit)
+
+      await refHelper.checkCommitInfo(
+        'token',
+        `Merge ${invalidHeadSha} into ${sha1Base}`,
+        repositoryOwner,
+        repositoryName,
+        ref,
+        commit
+      )
+
+      expect(getOctokitSpy).not.toHaveBeenCalled()
+      expect(repoGetSpy).not.toHaveBeenCalled()
+      expect(debugSpy).toHaveBeenCalledWith('Unexpected message format')
+    })
   })
 })

--- a/__test__/ref-helper.test.ts
+++ b/__test__/ref-helper.test.ts
@@ -3,6 +3,8 @@ import * as refHelper from '../lib/ref-helper'
 import {IGitCommandManager} from '../lib/git-command-manager'
 
 const commit = '1234567890123456789012345678901234567890'
+const sha256Commit =
+  '1234567890123456789012345678901234567890123456789012345678901234'
 let git: IGitCommandManager
 
 describe('ref-helper tests', () => {
@@ -34,6 +36,12 @@ describe('ref-helper tests', () => {
   it('getCheckoutInfo sha only', async () => {
     const checkoutInfo = await refHelper.getCheckoutInfo(git, '', commit)
     expect(checkoutInfo.ref).toBe(commit)
+    expect(checkoutInfo.startPoint).toBeFalsy()
+  })
+
+  it('getCheckoutInfo sha-256 only', async () => {
+    const checkoutInfo = await refHelper.getCheckoutInfo(git, '', sha256Commit)
+    expect(checkoutInfo.ref).toBe(sha256Commit)
     expect(checkoutInfo.startPoint).toBeFalsy()
   })
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2021,7 +2021,7 @@ function getInputs() {
             }
         }
         // SHA?
-        else if (result.ref.match(/^[0-9a-fA-F]{40}$/)) {
+        else if (result.ref.match(/^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/)) {
             result.commit = result.ref;
             result.ref = '';
         }
@@ -2444,7 +2444,7 @@ function checkCommitInfo(token, commitInfo, repositoryOwner, repositoryName, ref
                 return;
             }
             // Extract details from message
-            const match = commitInfo.match(/Merge ([0-9a-f]{40}) into ([0-9a-f]{40})/);
+            const match = commitInfo.match(/Merge ([0-9a-f]{40}|[0-9a-f]{64}) into ([0-9a-f]{40}|[0-9a-f]{64})/);
             if (!match) {
                 core.debug('Unexpected message format');
                 return;

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -71,7 +71,7 @@ export async function getInputs(): Promise<IGitSourceSettings> {
     }
   }
   // SHA?
-  else if (result.ref.match(/^[0-9a-fA-F]{40}$/)) {
+  else if (result.ref.match(/^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/)) {
     result.commit = result.ref
     result.ref = ''
   }

--- a/src/ref-helper.ts
+++ b/src/ref-helper.ts
@@ -258,7 +258,7 @@ export async function checkCommitInfo(
     }
 
     // Extract details from message
-    const match = commitInfo.match(/Merge ([0-9a-f]{40}) into ([0-9a-f]{40})/)
+    const match = commitInfo.match(/Merge ([0-9a-f]{40}|[0-9a-f]{64}) into ([0-9a-f]{40}|[0-9a-f]{64})/)
     if (!match) {
       core.debug('Unexpected message format')
       return

--- a/src/ref-helper.ts
+++ b/src/ref-helper.ts
@@ -258,7 +258,9 @@ export async function checkCommitInfo(
     }
 
     // Extract details from message
-    const match = commitInfo.match(/Merge ([0-9a-f]{40}|[0-9a-f]{64}) into ([0-9a-f]{40}|[0-9a-f]{64})/)
+    const match = commitInfo.match(
+      /Merge ([0-9a-f]{40}|[0-9a-f]{64}) into ([0-9a-f]{40}|[0-9a-f]{64})/
+    )
     if (!match) {
       core.debug('Unexpected message format')
       return


### PR DESCRIPTION
Fixes https://github.com/github/actions-runtime/issues/5476
Fixes https://github.com/github/actions-runtime/issues/5481
Fixes https://github.com/github/actions-runtime/issues/5482

## Summary
- expand merge commit SHA parsing in ref-helper to accept 40- and 64-character SHAs
- add SHA-256 coverage in input-helper and ref-helper tests
- include the coupled input-helper SHA regex update required for the new test coverage

*Automated by project-board-agents-plugin via /project-board-agents:lead*
*Board: https://github.com/orgs/github/projects/24272/views/1*
*Items: [P2] Fix merge commit SHA regex + [P2] Add SHA-256 test cases*
*Run: sha256-p2-checkout-00050*
