### PR TITLE
feat: warn on non-default checkout during pull_request_target

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ Please refer to the [release page](https://github.com/actions/checkout/releases/
     # running from unless specified. Example URLs are https://github.com or
     # https://my-ghes-server.example.com
     github-server-url: ''
+
+    # Suppress the warning when pull_request_target checks out a non-default branch
+    # from the workflow repository. Only set this to true when you understand the
+    # security risk of running untrusted pull request code in a privileged context.
+    # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+    # Default: false
+    dangerously-checkout-non-default-branch: ''
 ```
 <!-- end usage -->
 

--- a/__test__/input-helper.test.ts
+++ b/__test__/input-helper.test.ts
@@ -55,6 +55,15 @@ describe('input-helper tests', () => {
   beforeEach(() => {
     // Reset inputs
     inputs = {}
+    github.context.eventName = 'push'
+    github.context.ref = 'refs/heads/some-ref'
+    github.context.sha = '1234567890123456789012345678901234567890'
+    github.context.payload = {
+      repository: {
+        default_branch: 'main'
+      }
+    } as any
+    jest.clearAllMocks()
   })
 
   afterAll(() => {
@@ -65,6 +74,8 @@ describe('input-helper tests', () => {
     }
 
     // Restore @actions/github context
+    github.context.eventName = originalContext.eventName
+    github.context.payload = originalContext.payload
     github.context.ref = originalContext.ref
     github.context.sha = originalContext.sha
 
@@ -148,6 +159,75 @@ describe('input-helper tests', () => {
     const settings: IGitSourceSettings = await inputHelper.getInputs()
     expect(settings.ref).toBe('refs/heads/some-other-ref')
     expect(settings.commit).toBeFalsy()
+  })
+
+  it('warns when pull_request_target checks out a non-default branch', async () => {
+    github.context.eventName = 'pull_request_target'
+    inputs.ref = 'some-other-ref'
+
+    await inputHelper.getInputs()
+
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Checking out a non-default branch from pull_request_target'
+      )
+    )
+  })
+
+  it('does not warn when pull_request_target checks out the default branch name', async () => {
+    github.context.eventName = 'pull_request_target'
+    inputs.ref = 'main'
+
+    await inputHelper.getInputs()
+
+    expect(core.warning).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when pull_request_target checks out the fully qualified default branch', async () => {
+    github.context.eventName = 'pull_request_target'
+    inputs.ref = 'refs/heads/main'
+
+    await inputHelper.getInputs()
+
+    expect(core.warning).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when pull_request_target checks out the default branch sha', async () => {
+    github.context.eventName = 'pull_request_target'
+    inputs.ref = '1234567890123456789012345678901234567890'
+
+    await inputHelper.getInputs()
+
+    expect(core.warning).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when dangerously-checkout-non-default-branch suppresses the warning', async () => {
+    github.context.eventName = 'pull_request_target'
+    inputs.ref = 'some-other-ref'
+    inputs['dangerously-checkout-non-default-branch'] = 'true'
+
+    await inputHelper.getInputs()
+
+    expect(core.warning).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when pull_request checks out a non-default branch', async () => {
+    github.context.eventName = 'pull_request'
+    inputs.ref = 'some-other-ref'
+
+    await inputHelper.getInputs()
+
+    expect(core.warning).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when pull_request_target checks out a different repository', async () => {
+    github.context.eventName = 'pull_request_target'
+    inputs.repository = 'some-owner/some-other-repo'
+    inputs.ref = 'some-other-ref'
+
+    await inputHelper.getInputs()
+
+    expect(core.warning).not.toHaveBeenCalled()
   })
 
   it('sets workflow organization ID', async () => {

--- a/action.yml
+++ b/action.yml
@@ -98,6 +98,14 @@ inputs:
   github-server-url:
     description: The base URL for the GitHub instance that you are trying to clone from, will use environment defaults to fetch from the same instance that the workflow is running from unless specified. Example URLs are https://github.com or https://my-ghes-server.example.com
     required: false
+  dangerously-checkout-non-default-branch:
+    description: >
+      Suppress the warning when pull_request_target checks out a non-default
+      branch from the workflow repository. Only set this to true when you
+      understand the security risk of running untrusted pull request code in a
+      privileged context.
+      https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+    default: false
 outputs:
   ref:
     description: 'The branch, tag or SHA that was checked out'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2008,7 +2008,8 @@ function getInputs() {
         const isWorkflowRepository = qualifiedRepository.toUpperCase() ===
             `${github.context.repo.owner}/${github.context.repo.repo}`.toUpperCase();
         // Source branch, source version
-        result.ref = core.getInput('ref');
+        const inputRef = core.getInput('ref');
+        result.ref = inputRef;
         if (!result.ref) {
             if (isWorkflowRepository) {
                 result.ref = github.context.ref;
@@ -2027,6 +2028,16 @@ function getInputs() {
         }
         core.debug(`ref = '${result.ref}'`);
         core.debug(`commit = '${result.commit}'`);
+        // Warn when pull_request_target checks out non-default code from the workflow repository.
+        // This event runs in the base repository context, so checking out PR-controlled code can be risky.
+        const suppressNonDefaultBranchWarning = (core.getInput('dangerously-checkout-non-default-branch') || 'false').toUpperCase() === 'TRUE';
+        if (github.context.eventName === 'pull_request_target' &&
+            isWorkflowRepository &&
+            inputRef &&
+            !suppressNonDefaultBranchWarning &&
+            !isDefaultBranchRef(inputRef)) {
+            core.warning('Checking out a non-default branch from pull_request_target can put untrusted pull request code in a privileged context. If this is intentional, set dangerously-checkout-non-default-branch: true. Consider using pull_request or pull_request plus workflow_run instead. See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/');
+        }
         // Clean
         result.clean = (core.getInput('clean') || 'true').toUpperCase() === 'TRUE';
         core.debug(`clean = ${result.clean}`);
@@ -2097,6 +2108,15 @@ function getInputs() {
         core.debug(`GitHub Host URL = ${result.githubServerUrl}`);
         return result;
     });
+}
+function isDefaultBranchRef(ref) {
+    var _a;
+    const defaultBranch = (_a = github.context.payload.repository) === null || _a === void 0 ? void 0 : _a.default_branch;
+    if (defaultBranch &&
+        (ref === defaultBranch || ref === `refs/heads/${defaultBranch}`)) {
+        return true;
+    }
+    return ref.toUpperCase() === github.context.sha.toUpperCase();
 }
 
 

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -57,7 +57,8 @@ export async function getInputs(): Promise<IGitSourceSettings> {
     `${github.context.repo.owner}/${github.context.repo.repo}`.toUpperCase()
 
   // Source branch, source version
-  result.ref = core.getInput('ref')
+  const inputRef = core.getInput('ref')
+  result.ref = inputRef
   if (!result.ref) {
     if (isWorkflowRepository) {
       result.ref = github.context.ref
@@ -77,6 +78,24 @@ export async function getInputs(): Promise<IGitSourceSettings> {
   }
   core.debug(`ref = '${result.ref}'`)
   core.debug(`commit = '${result.commit}'`)
+
+  // Warn when pull_request_target checks out non-default code from the workflow repository.
+  // This event runs in the base repository context, so checking out PR-controlled code can be risky.
+  const suppressNonDefaultBranchWarning =
+    (
+      core.getInput('dangerously-checkout-non-default-branch') || 'false'
+    ).toUpperCase() === 'TRUE'
+  if (
+    github.context.eventName === 'pull_request_target' &&
+    isWorkflowRepository &&
+    inputRef &&
+    !suppressNonDefaultBranchWarning &&
+    !isDefaultBranchRef(inputRef)
+  ) {
+    core.warning(
+      'Checking out a non-default branch from pull_request_target can put untrusted pull request code in a privileged context. If this is intentional, set dangerously-checkout-non-default-branch: true. Consider using pull_request or pull_request plus workflow_run instead. See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/'
+    )
+  }
 
   // Clean
   result.clean = (core.getInput('clean') || 'true').toUpperCase() === 'TRUE'
@@ -162,4 +181,17 @@ export async function getInputs(): Promise<IGitSourceSettings> {
   core.debug(`GitHub Host URL = ${result.githubServerUrl}`)
 
   return result
+}
+
+function isDefaultBranchRef(ref: string): boolean {
+  const defaultBranch = (github.context.payload.repository as any)
+    ?.default_branch
+  if (
+    defaultBranch &&
+    (ref === defaultBranch || ref === `refs/heads/${defaultBranch}`)
+  ) {
+    return true
+  }
+
+  return ref.toUpperCase() === github.context.sha.toUpperCase()
 }


### PR DESCRIPTION
Hello team, thanks for your continued contributions to the OSS community! 👋 

## Summary

This PR adds a warning when `actions/checkout` is used from a `pull_request_target` workflow to explicitly check out a non-default branch (or ref) from the workflow repository.

The intent is not to block every such workflow. There may be legitimate cases where a workflow intentionally treats pull request contents as passive data. However, in practice, checking out a pull request-controlled ref in `pull_request_target` is easy to misunderstand and can put untrusted code into a privileged workflow context.

This pattern was part of the issue described in the TanStack npm supply-chain compromise postmortem:

https://tanstack.com/blog/npm-supply-chain-compromise-postmortem

GitHub Security Lab has also documented this class of problem as “pwn requests”:

https://securitylab.github.com/resources/github-actions-preventing-pwn-requests

## Proposed behavior

When all of the following are true, the action emits a warning:

- the workflow event is `pull_request_target`
- the checked-out repository is the workflow repository
- `with.ref` is explicitly set
- the ref does not resolve to the default branch or the default branch SHA

The warning can be suppressed with:

```yaml
with:
  dangerously-checkout-non-default-branch: true
```

The dangerously prefix is intentional. The goal is to make the risky case explicit in workflow code, while still allowing maintainers who understand the tradeoff to opt out of the warning.

## Why this seems worth considering

This is a relatively small change, but I think it could help the broader Actions community avoid a recurring footgun. The current behavior is technically flexible, but the security implications of pull_request_target are subtle enough that a warning at the point of use seems valuable.

I am opening this PR as a starting point for discussion. I would be happy to adjust the wording, the option name, or the exact detection logic based on maintainer feedback.

Thank you!