### PR TITLE
Allows subpaths in GITHUB_SERVER_URL

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2731,7 +2731,8 @@ function getFetchUrl(settings) {
         return `${user}@${serviceUrl.hostname}:${encodedOwner}/${encodedName}.git`;
     }
     // "origin" is SCHEME://HOSTNAME[:PORT]
-    return `${serviceUrl.origin}/${encodedOwner}/${encodedName}`;
+    const serviceUrlBase = pruneSuffix(`${serviceUrl.origin}${serviceUrl.pathname}`, '/');
+    return `${serviceUrlBase}/${encodedOwner}/${encodedName}`;
 }
 function getServerUrl(url) {
     let resolvedUrl = process.env['GITHUB_SERVER_URL'] || 'https://github.com';

--- a/src/url-helper.ts
+++ b/src/url-helper.ts
@@ -17,7 +17,11 @@ export function getFetchUrl(settings: IGitSourceSettings): string {
   }
 
   // "origin" is SCHEME://HOSTNAME[:PORT]
-  return `${serviceUrl.origin}/${encodedOwner}/${encodedName}`
+  const serviceUrlBase = pruneSuffix(
+    `${serviceUrl.origin}${serviceUrl.pathname}`,
+    '/'
+  )
+  return `${serviceUrlBase}/${encodedOwner}/${encodedName}`
 }
 
 export function getServerUrl(url?: string): URL {


### PR DESCRIPTION
This is needed for selfhosted Gitea instances, that are running in subpaths like https://fx-world.de/gitea

Would solve Tickets like https://github.com/actions/checkout/issues/1817