### PR TITLE
feat: support custom SSH user in git auth configuration with submodules to support GHEC

### DIFF
--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -995,6 +995,91 @@ describe('git-auth-helper tests', () => {
     ).toBe(false)
     expect((authHelper as any).testCredentialsConfigPath('')).toBe(false)
   })
+
+  const configureAuth_uses_default_git_user_when_sshUser_empty =
+    'configureAuth uses default git user when sshUser is empty'
+  it(configureAuth_uses_default_git_user_when_sshUser_empty, async () => {
+    // Arrange
+    await setup(configureAuth_uses_default_git_user_when_sshUser_empty)
+    settings.sshUser = ''
+    settings.sshKey = ''
+    const authHelper = gitAuthHelper.createAuthHelper(git, settings)
+
+    // Act
+    await authHelper.configureAuth()
+    await authHelper.configureGlobalAuth()
+
+    // Assert - verify that git@github.com is in the insteadOf config
+    const home = git.env['HOME'] || tempHomedir
+    const configContent = (
+      await fs.promises.readFile(path.join(home, '.gitconfig'))
+    ).toString()
+    expect(configContent.indexOf('url.https://github.com/.insteadOf git@github.com')).toBeGreaterThanOrEqual(0)
+  })
+
+  const configureAuth_uses_custom_ssh_user_when_sshUser_provided =
+    'configureAuth uses custom SSH user when sshUser is provided'
+  it(configureAuth_uses_custom_ssh_user_when_sshUser_provided, async () => {
+    // Arrange
+    await setup(configureAuth_uses_custom_ssh_user_when_sshUser_provided)
+    settings.sshUser = 'customuser'
+    settings.sshKey = ''
+    const authHelper = gitAuthHelper.createAuthHelper(git, settings)
+
+    // Act
+    await authHelper.configureAuth()
+    await authHelper.configureGlobalAuth()
+
+    // Assert - verify that customuser@github.com is in the insteadOf config
+    const home = git.env['HOME'] || tempHomedir
+    const configContent = (
+      await fs.promises.readFile(path.join(home, '.gitconfig'))
+    ).toString()
+    expect(configContent.indexOf('url.https://github.com/.insteadOf customuser@github.com')).toBeGreaterThanOrEqual(0)
+  })
+
+  const configureGlobalAuth_with_custom_sshUser =
+    'configureGlobalAuth with custom sshUser'
+  it(configureGlobalAuth_with_custom_sshUser, async () => {
+    // Arrange
+    await setup(configureGlobalAuth_with_custom_sshUser)
+    settings.sshUser = 'admin'
+    settings.sshKey = ''
+    const authHelper = gitAuthHelper.createAuthHelper(git, settings)
+
+    // Act
+    await authHelper.configureAuth()
+    await authHelper.configureGlobalAuth()
+
+    // Assert - verify the .insteadOf config contains the custom user
+    const home = git.env['HOME'] || tempHomedir
+    const configContent = (
+      await fs.promises.readFile(path.join(home, '.gitconfig'))
+    ).toString()
+    expect(configContent.indexOf('url.https://github.com/.insteadOf admin@github.com')).toBeGreaterThanOrEqual(0)
+  })
+
+  const configureSubmoduleAuth_with_custom_sshUser =
+    'configureSubmoduleAuth with custom sshUser'
+  it(configureSubmoduleAuth_with_custom_sshUser, async () => {
+    // Arrange
+    await setup(configureSubmoduleAuth_with_custom_sshUser)
+    settings.sshUser = 'deploy'
+    settings.sshKey = ''
+    const authHelper = gitAuthHelper.createAuthHelper(git, settings)
+    await authHelper.configureAuth()
+    const mockSubmoduleForeach = git.submoduleForeach as jest.Mock<any>
+    mockSubmoduleForeach.mockClear()
+
+    // Act
+    await authHelper.configureSubmoduleAuth()
+
+    // Assert - verify the insteadOf config uses the custom user
+    expect(mockSubmoduleForeach).toHaveBeenCalledTimes(3)
+    expect(mockSubmoduleForeach.mock.calls[1][0]).toMatch(
+      /url.*insteadOf.*deploy@github.com:/
+    )
+  })
 })
 
 async function setup(testName: string): Promise<void> {

--- a/dist/index.js
+++ b/dist/index.js
@@ -35063,7 +35063,10 @@ class GitAuthHelper {
         this.tokenConfigValue = `AUTHORIZATION: basic ${basicCredential}`;
         // Instead of SSH URL
         this.insteadOfKey = `url.${serverUrl.origin}/.insteadOf`; // "origin" is SCHEME://HOSTNAME[:PORT]
-        this.insteadOfValues.push(`git@${serverUrl.hostname}:`);
+        const sshUser = this.settings.sshUser && this.settings.sshUser.length > 0
+            ? this.settings.sshUser
+            : 'git';
+        this.insteadOfValues.push(`${sshUser}@${serverUrl.hostname}:`);
         if (this.settings.workflowOrganizationId) {
             this.insteadOfValues.push(`org-${this.settings.workflowOrganizationId}@github.com:`);
         }

--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -65,7 +65,11 @@ class GitAuthHelper {
 
     // Instead of SSH URL
     this.insteadOfKey = `url.${serverUrl.origin}/.insteadOf` // "origin" is SCHEME://HOSTNAME[:PORT]
-    this.insteadOfValues.push(`git@${serverUrl.hostname}:`)
+    const sshUser =
+      this.settings.sshUser && this.settings.sshUser.length > 0
+        ? this.settings.sshUser
+        : 'git'
+    this.insteadOfValues.push(`${sshUser}@${serverUrl.hostname}:`)
     if (this.settings.workflowOrganizationId) {
       this.insteadOfValues.push(
         `org-${this.settings.workflowOrganizationId}@github.com:`


### PR DESCRIPTION
I have tested it on our instance of GHEC and it works.
We are using an github installation app token to checkout repos including submoduls:

That was the tested workflow:
```yml
name: Checkout
on: push
permissions:
  contents: read
jobs:
  submodule:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
      id: app-token
      with:
        owner: ORG
        app-id: 9999
        private-key: ${{ secrets.GLOBAL_APP_PRIVATE_KEY }}
    - uses: axi92/checkout@227ee32e4d03db3bcfa49e59da34f56ee6f0d2c8
      with:
        ref: ${{ github.head_ref }}
        token: ${{ steps.app-token.outputs.token }}
        ssh-user: 'custom'
        submodules: true
```

- Allow sshUser setting to override default 'git' user in insteadOf config
- When sshUser is empty, default to 'git@github.com'
- When sshUser is provided (e.g., 'customuser'), use 'customuser@github.com'
- Updated tests to verify custom SSH user behavior in auth configuration

This resolves #2417