### PR TITLE
Fix checkout init for SHA-256 repositories

### DIFF
--- a/__test__/git-command-manager.test.ts
+++ b/__test__/git-command-manager.test.ts
@@ -378,6 +378,59 @@ describe('Test fetchDepth and fetchTags options', () => {
   })
 })
 
+describe('repository initialization object format', () => {
+  beforeEach(async () => {
+    jest.spyOn(fshelper, 'fileExistsSync').mockImplementation(jest.fn())
+    jest.spyOn(fshelper, 'directoryExistsSync').mockImplementation(jest.fn())
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('initializes SHA-256 repositories with the matching object format', async () => {
+    mockExec.mockImplementation((path, args, options) => {
+      if (args.includes('version')) {
+        options.listeners.stdout(Buffer.from('git version 2.50.1'))
+      }
+
+      return 0
+    })
+    jest.spyOn(exec, 'exec').mockImplementation(mockExec)
+
+    git = await commandManager.createCommandManager('test', false, false)
+
+    await git.init('sha256')
+
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.any(String),
+      ['init', '--object-format=sha256', 'test'],
+      expect.any(Object)
+    )
+  })
+
+  it('initializes SHA-1 repositories with existing default arguments', async () => {
+    mockExec.mockImplementation((path, args, options) => {
+      if (args.includes('version')) {
+        options.listeners.stdout(Buffer.from('git version 2.50.1'))
+      }
+
+      return 0
+    })
+    jest.spyOn(exec, 'exec').mockImplementation(mockExec)
+
+    git = await commandManager.createCommandManager('test', false, false)
+
+    await git.init('sha1')
+
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.any(String),
+      ['init', 'test'],
+      expect.any(Object)
+    )
+  })
+})
+
 describe('git user-agent with orchestration ID', () => {
   beforeEach(async () => {
     jest.spyOn(fshelper, 'fileExistsSync').mockImplementation(jest.fn())

--- a/__test__/github-api-helper.test.ts
+++ b/__test__/github-api-helper.test.ts
@@ -1,0 +1,98 @@
+import * as core from '@actions/core'
+import * as github from '@actions/github'
+import * as githubApiHelper from '../lib/github-api-helper'
+
+describe('github-api-helper object format', () => {
+  let getOctokitSpy: jest.SpyInstance
+  let debugSpy: jest.SpyInstance
+  let request: jest.Mock
+
+  function mockHashAlgorithmApi(hashAlgorithm: string): void {
+    request = jest.fn(async () => ({
+      data: {
+        hash_algorithm: hashAlgorithm
+      }
+    }))
+    getOctokitSpy = jest.spyOn(github, 'getOctokit').mockReturnValue({
+      request
+    } as any)
+  }
+
+  beforeEach(() => {
+    debugSpy = jest.spyOn(core, 'debug').mockImplementation(jest.fn())
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('detects SHA-256 from the repository hash algorithm endpoint', async () => {
+    mockHashAlgorithmApi('sha256')
+
+    await expect(
+      githubApiHelper.tryGetRepositoryObjectFormat('token', 'owner', 'repo')
+    ).resolves.toEqual({format: 'sha256', succeeded: true})
+
+    expect(getOctokitSpy).toHaveBeenCalledWith(
+      'token',
+      expect.objectContaining({baseUrl: 'https://api.github.com'})
+    )
+    expect(request).toHaveBeenCalledWith(
+      'GET /repos/{owner}/{repo}/hash-algorithm',
+      {owner: 'owner', repo: 'repo'}
+    )
+  })
+
+  it('detects SHA-1 from the repository hash algorithm endpoint', async () => {
+    mockHashAlgorithmApi('sha1')
+
+    await expect(
+      githubApiHelper.tryGetRepositoryObjectFormat('token', 'owner', 'repo')
+    ).resolves.toEqual({format: 'sha1', succeeded: true})
+  })
+
+  it('detects object format from an existing commit without API calls', async () => {
+    const commitSha =
+      '9422233ca7ee1b17f1e905d0e141faf0c401556c41cdc6acd71c6bd685da2e92'
+    getOctokitSpy = jest.spyOn(github, 'getOctokit')
+
+    await expect(
+      githubApiHelper.tryGetRepositoryObjectFormat(
+        'token',
+        'owner',
+        'repo',
+        undefined,
+        commitSha
+      )
+    ).resolves.toEqual({format: 'sha256', succeeded: true})
+
+    expect(getOctokitSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns unsuccessful when the hash algorithm endpoint value is not recognized', async () => {
+    mockHashAlgorithmApi('unknown')
+
+    await expect(
+      githubApiHelper.tryGetRepositoryObjectFormat('token', 'owner', 'repo')
+    ).resolves.toEqual({format: '', succeeded: false})
+    expect(debugSpy).toHaveBeenCalledWith(
+      'Unable to determine repository object format from hash-algorithm endpoint'
+    )
+  })
+
+  it('returns unsuccessful when the hash algorithm API lookup fails', async () => {
+    request = jest.fn(async () => {
+      throw new Error('not found')
+    })
+    jest.spyOn(github, 'getOctokit').mockReturnValue({
+      request
+    } as any)
+
+    await expect(
+      githubApiHelper.tryGetRepositoryObjectFormat('token', 'owner', 'repo')
+    ).resolves.toEqual({format: '', succeeded: false})
+    expect(debugSpy).toHaveBeenCalledWith(
+      'Unable to determine repository object format from hash-algorithm endpoint: not found'
+    )
+  })
+})

--- a/dist/index.js
+++ b/dist/index.js
@@ -896,9 +896,14 @@ class GitCommandManager {
     getWorkingDirectory() {
         return this.workingDirectory;
     }
-    init() {
+    init(objectFormat) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield this.execGit(['init', this.workingDirectory]);
+            const args = ['init'];
+            if (objectFormat === 'sha256') {
+                args.push('--object-format=sha256');
+            }
+            args.push(this.workingDirectory);
+            yield this.execGit(args);
         });
     }
     isDetached() {
@@ -1486,8 +1491,17 @@ function getSource(settings) {
             stateHelper.setRepositoryPath(settings.repositoryPath);
             // Initialize the repository
             if (!fsHelper.directoryExistsSync(path.join(settings.repositoryPath, '.git'))) {
+                core.startGroup('Determining repository object format');
+                const objectFormatResult = yield githubApiHelper.tryGetRepositoryObjectFormat(settings.authToken, settings.repositoryOwner, settings.repositoryName, settings.githubServerUrl, settings.commit);
+                const objectFormat = objectFormatResult.succeeded
+                    ? objectFormatResult.format
+                    : '';
+                if (objectFormat === 'sha256') {
+                    core.info('Detected SHA-256 repository object format');
+                }
+                core.endGroup();
                 core.startGroup('Initializing the repository');
-                yield git.init();
+                yield git.init(objectFormat);
                 yield git.remoteAdd('origin', repositoryUrl);
                 core.endGroup();
             }
@@ -1810,6 +1824,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.downloadRepository = downloadRepository;
 exports.getDefaultBranch = getDefaultBranch;
+exports.tryGetRepositoryObjectFormat = tryGetRepositoryObjectFormat;
 const assert = __importStar(__nccwpck_require__(9491));
 const core = __importStar(__nccwpck_require__(2186));
 const fs = __importStar(__nccwpck_require__(7147));
@@ -1910,6 +1925,40 @@ function getDefaultBranch(authToken, owner, repo, baseUrl) {
             return result;
         }));
     });
+}
+function tryGetRepositoryObjectFormat(authToken, owner, repo, baseUrl, commit) {
+    return __awaiter(this, void 0, void 0, function* () {
+        var _a;
+        const commitFormat = getObjectFormat(commit);
+        if (commitFormat) {
+            return { format: commitFormat, succeeded: true };
+        }
+        try {
+            const octokit = github.getOctokit(authToken, {
+                baseUrl: (0, url_helper_1.getServerApiUrl)(baseUrl)
+            });
+            const response = yield octokit.request('GET /repos/{owner}/{repo}/hash-algorithm', { owner, repo });
+            const hashAlgorithm = response.data.hash_algorithm;
+            if (hashAlgorithm === 'sha256' || hashAlgorithm === 'sha1') {
+                return { format: hashAlgorithm, succeeded: true };
+            }
+            core.debug('Unable to determine repository object format from hash-algorithm endpoint');
+            return { format: '', succeeded: false };
+        }
+        catch (err) {
+            core.debug(`Unable to determine repository object format from hash-algorithm endpoint: ${(_a = err === null || err === void 0 ? void 0 : err.message) !== null && _a !== void 0 ? _a : err}`);
+            return { format: '', succeeded: false };
+        }
+    });
+}
+function getObjectFormat(sha) {
+    if (/^[0-9a-fA-F]{64}$/.test(sha || '')) {
+        return 'sha256';
+    }
+    if (/^[0-9a-fA-F]{40}$/.test(sha || '')) {
+        return 'sha1';
+    }
+    return '';
 }
 function downloadArchive(authToken, owner, repo, ref, commit, baseUrl) {
     return __awaiter(this, void 0, void 0, function* () {

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -43,7 +43,7 @@ export interface IGitCommandManager {
   getDefaultBranch(repositoryUrl: string): Promise<string>
   getSubmoduleConfigPaths(recursive: boolean): Promise<string[]>
   getWorkingDirectory(): string
-  init(): Promise<void>
+  init(objectFormat?: string): Promise<void>
   isDetached(): Promise<boolean>
   lfsFetch(ref: string): Promise<void>
   lfsInstall(): Promise<void>
@@ -364,8 +364,14 @@ class GitCommandManager {
     return this.workingDirectory
   }
 
-  async init(): Promise<void> {
-    await this.execGit(['init', this.workingDirectory])
+  async init(objectFormat?: string): Promise<void> {
+    const args = ['init']
+    if (objectFormat === 'sha256') {
+      args.push('--object-format=sha256')
+    }
+    args.push(this.workingDirectory)
+
+    await this.execGit(args)
   }
 
   async isDetached(): Promise<boolean> {

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -109,8 +109,25 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
     if (
       !fsHelper.directoryExistsSync(path.join(settings.repositoryPath, '.git'))
     ) {
+      core.startGroup('Determining repository object format')
+      const objectFormatResult =
+        await githubApiHelper.tryGetRepositoryObjectFormat(
+          settings.authToken,
+          settings.repositoryOwner,
+          settings.repositoryName,
+          settings.githubServerUrl,
+          settings.commit
+        )
+      const objectFormat = objectFormatResult.succeeded
+        ? objectFormatResult.format
+        : ''
+      if (objectFormat === 'sha256') {
+        core.info('Detected SHA-256 repository object format')
+      }
+      core.endGroup()
+
       core.startGroup('Initializing the repository')
-      await git.init()
+      await git.init(objectFormat)
       await git.remoteAdd('origin', repositoryUrl)
       core.endGroup()
     }

--- a/src/github-api-helper.ts
+++ b/src/github-api-helper.ts
@@ -11,6 +11,12 @@ import {getServerApiUrl} from './url-helper'
 
 const IS_WINDOWS = process.platform === 'win32'
 
+export interface RepositoryObjectFormatResult {
+  defaultBranch?: string
+  format: string
+  succeeded: boolean
+}
+
 export async function downloadRepository(
   authToken: string,
   owner: string,
@@ -120,6 +126,53 @@ export async function getDefaultBranch(
 
     return result
   })
+}
+
+export async function tryGetRepositoryObjectFormat(
+  authToken: string,
+  owner: string,
+  repo: string,
+  baseUrl?: string,
+  commit?: string
+): Promise<RepositoryObjectFormatResult> {
+  const commitFormat = getObjectFormat(commit)
+  if (commitFormat) {
+    return {format: commitFormat, succeeded: true}
+  }
+
+  try {
+    const octokit = github.getOctokit(authToken, {
+      baseUrl: getServerApiUrl(baseUrl)
+    })
+    const response = await octokit.request(
+      'GET /repos/{owner}/{repo}/hash-algorithm',
+      {owner, repo}
+    )
+    const hashAlgorithm = response.data.hash_algorithm
+    if (hashAlgorithm === 'sha256' || hashAlgorithm === 'sha1') {
+      return {format: hashAlgorithm, succeeded: true}
+    }
+
+    core.debug(
+      'Unable to determine repository object format from hash-algorithm endpoint'
+    )
+    return {format: '', succeeded: false}
+  } catch (err) {
+    core.debug(
+      `Unable to determine repository object format from hash-algorithm endpoint: ${(err as any)?.message ?? err}`
+    )
+    return {format: '', succeeded: false}
+  }
+}
+
+function getObjectFormat(sha?: string): string {
+  if (/^[0-9a-fA-F]{64}$/.test(sha || '')) {
+    return 'sha256'
+  }
+  if (/^[0-9a-fA-F]{40}$/.test(sha || '')) {
+    return 'sha1'
+  }
+  return ''
 }
 
 async function downloadArchive(

--- a/src/github-api-helper.ts
+++ b/src/github-api-helper.ts
@@ -12,7 +12,6 @@ import {getServerApiUrl} from './url-helper'
 const IS_WINDOWS = process.platform === 'win32'
 
 export interface RepositoryObjectFormatResult {
-  defaultBranch?: string
   format: string
   succeeded: boolean
 }


### PR DESCRIPTION
## Summary

Fixes github/actions-runtime#5528 by initializing checkout's local Git repository with the object format used by the target repository.

SHA-256 repositories fail today because checkout creates the local repository with plain `git init` before fetching. Plain `git init` creates a SHA-1 repository by default, so the later fetch from a SHA-256 remote fails with a client/server object-format mismatch unless the workflow manually sets `GIT_DEFAULT_HASH=sha256`.

This PR updates checkout to:

- determine the target repository object format before `git init`
- use an existing commit SHA directly when checkout already has one
- otherwise call `GET /repos/{owner}/{repo}/hash-algorithm`
- run `git init --object-format=sha256` only when the repository is identified as SHA-256
- preserve checkout's existing default `git init` behavior for SHA-1 repositories and for cases where the format is not identified

## Why this approach

Checkout has to choose the local repository object format before the first fetch. The hash-algorithm endpoint uses the existing action token through Octokit and works before a `.git` directory exists, so it supports private repositories without setting up Git credential config early.

The endpoint returns `hash_algorithm` as `sha1` or `sha256`. Checkout uses that value directly instead of inferring the repository format from a branch commit SHA.

When checkout already has a 40- or 64-character commit SHA, it can determine the object format from that SHA without an API request. Otherwise, object-format detection is one pre-init API request to the hash-algorithm endpoint.

Checkout only opts into SHA-256 initialization after a positive SHA-256 result; otherwise it preserves the existing initialization path.

## Security notes

The pre-init detection uses the existing Octokit/API authentication path and does not require writing Git credentials before repository initialization. Normal checkout authentication still happens through the existing auth helper flow, including the existing cleanup behavior for `persist-credentials: false`.

## Validation

- `npm run build`
- `npm test -- --runInBand`
- `npm run format-check`
- `npm run lint`
- unit coverage verifies the `GET /repos/{owner}/{repo}/hash-algorithm` request and `sha1`/`sha256` responses
