### PR TITLE
docs(action): fix inaccuracies and add missing metadata to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ inputs:
       The branch, tag or SHA to checkout. When checking out the repository that
       triggered a workflow, this defaults to the reference or SHA for that
       event.  Otherwise, uses the default branch.
+    required: false
   token:
     description: >
       Personal access token (PAT) used to fetch the repository. The PAT is configured
@@ -34,11 +35,13 @@ inputs:
 
       [Learn more about creating and using
       encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
+    required: false
   ssh-known-hosts:
     description: >
       Known hosts in addition to the user and global host key database. The public
       SSH keys for a host may be obtained using the utility `ssh-keyscan`. For example,
       `ssh-keyscan github.com`. The public key for github.com is always implicitly added.
+    required: false
   ssh-strict:
     description: >
       Whether to perform strict host key checking. When true, adds the options `StrictHostKeyChecking=yes`
@@ -50,23 +53,30 @@ inputs:
       The user to use when connecting to the remote SSH host. By default 'git' is used.
     default: git
   persist-credentials:
-    description: 'Whether to configure the token or SSH key with the local git config'
+    description: >
+      Whether to persist the token or SSH key credentials for use by subsequent
+      steps. When true, credentials are stored in a file under `$RUNNER_TEMP`
+      and referenced from the local git config. The post-job step removes the
+      credential file.
     default: true
   path:
     description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
+    default: '.'
+    required: false
   clean:
     description: 'Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching'
     default: true
   filter:
     description: >
-      Partially clone against a given filter.
-      Overrides sparse-checkout if set.
-    default: null
+      Partially clone against a given filter. When `sparse-checkout` is also
+      set, overrides the default `blob:none` filter that would otherwise be
+      used for fetching.
+    required: false
   sparse-checkout:
     description: >
       Do a sparse checkout on given patterns.
       Each pattern should be separated with new lines.
-    default: null
+    required: false
   sparse-checkout-cone-mode:
     description: >
       Specifies whether to use cone-mode when doing a sparse checkout.
@@ -100,9 +110,13 @@ inputs:
     required: false
 outputs:
   ref:
-    description: 'The branch, tag or SHA that was checked out'
+    description: >
+      The branch or tag ref that was checked out. Empty when the checkout was
+      performed by a full commit SHA.
   commit:
-    description: 'The commit SHA that was checked out'
+    description: >
+      The commit SHA that was checked out. Only set when Git is available (not
+      set when the repository was downloaded via the GitHub REST API fallback).
 runs:
   using: node24
   main: dist/index.js


### PR DESCRIPTION
## Summary
Corrects and completes the metadata in `action.yml` to accurately reflect the runtime behavior of the action. No behavioral changes — documentation only.

## Changes
- **`persist-credentials` description**: Updated to reflect the v6 change where credentials are stored in a file under `$RUNNER_TEMP` (not written directly
  into `.git/config`), and that the post-job step removes that file.
- **`filter` description**: Replaced the incorrect "Overrides sparse-checkout if set" with an accurate explanation — when `filter` and `sparse-checkout` are both set, the provided filter is used for `git fetch` instead of the automatic `blob:none`; sparse checkout itself still runs.
- **`filter` / `sparse-checkout` defaults**: Removed `default: null`. YAML `null` is not a meaningful default for optional string inputs; omitting the key correctly signals no default value.
- **`path` default**: Added `default: '.'` to document the code-level fallback (`core.getInput('path') || '.'`).
- **`required: false`**: Added to all optional inputs that had no explicit `required` field (`ref`, `ssh-key`, `ssh-known-hosts`, `path`, `filter`, `sparse-checkout`, `github-server-url`).
- **`ref` output description**: Corrected — when the `ref` input is a full 40- or 64-character SHA, the code sets `sourceSettings.ref = ''`, so this output is empty for SHA-based checkouts.
- **`commit` output description**: Added caveat that this output is only emitted in the git code path (`git log --format=%H`); it is never set when the action falls back to the GitHub REST API downloader.

## Motivation
Several descriptions in `action.yml` were stale (written before the v6 credential storage change), inaccurate (`filter` description, output descriptions), or incomplete (missing defaults and `required` flags). These inconsistencies could mislead users relying on the marketplace UI, tooling that parses `action.yml`, or anyone reading the source to understand the contract.

## Impact
- **Users**: No behavioral change. All input/output names and defaults remain backward compatible.
- **Tooling**: Tools that parse `action.yml` (e.g., IDE extensions, linters, action documentation generators) will now see correct `required` and `default` values.
- **`path` default**: Consumers setting `path: '.'` explicitly may notice it is now the documented default — no functional difference.

## Testing
Documentation-only change. Validated by cross-referencing each modified field against the implementation in:

| File | Verified |
|---|---|
| `src/input-helper.ts` | Input defaults and `required` semantics |
| `src/git-source-provider.ts` | `commit` output only emitted in git path |
| `src/main.ts` | `ref` output and SHA-based ref handling |
| `src/git-auth-helper.ts` | `persist-credentials` / `$RUNNER_TEMP` behavior |
