### PR TITLE
Update changelog for v6.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.0.3
+* Fix checkout init for SHA-256 repositories by @yaananth in https://github.com/actions/checkout/pull/2439
+* fix: expand merge commit SHA regex and add SHA-256 test cases by @yaananth in https://github.com/actions/checkout/pull/2414
+
 ## v6.0.2
 * Fix tag handling: preserve annotations and explicit fetch-tags by @ericsciple in https://github.com/actions/checkout/pull/2356
 


### PR DESCRIPTION
Updates `CHANGELOG.md` for the v6.0.3 release.

Includes:
- SHA-256 repository checkout initialization support (#2439)
- SHA-256 merge commit matching/test coverage (#2414)
