### PR TITLE
Fix global auth when GIT_CONFIG_GLOBAL is set in the environment

### DIFF
--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -923,6 +923,25 @@ describe('git-auth-helper tests', () => {
     }
   })
 
+  const configureGlobalAuth_overridesGitConfigGlobal =
+    'configureGlobalAuth overrides GIT_CONFIG_GLOBAL'
+  it(configureGlobalAuth_overridesGitConfigGlobal, async () => {
+    // Arrange
+    await setup(configureGlobalAuth_overridesGitConfigGlobal)
+    const authHelper = gitAuthHelper.createAuthHelper(git, settings)
+
+    // Act
+    await authHelper.configureAuth()
+    await authHelper.configureGlobalAuth()
+
+    // Assert GIT_CONFIG_GLOBAL is pinned to the temporary global config, so an
+    // inherited GIT_CONFIG_GLOBAL cannot redirect --global writes
+    expect(git.env['HOME']).toBeTruthy()
+    expect(git.env['GIT_CONFIG_GLOBAL']).toBe(
+      path.join(git.env['HOME'], '.gitconfig')
+    )
+  })
+
   const removeGlobalConfig_removesOverride =
     'removeGlobalConfig removes override'
   it(removeGlobalConfig_removesOverride, async () => {
@@ -933,6 +952,7 @@ describe('git-auth-helper tests', () => {
     await authHelper.configureGlobalAuth()
     const homeOverride = git.env['HOME'] // Sanity check
     expect(homeOverride).toBeTruthy()
+    expect(git.env['GIT_CONFIG_GLOBAL']).toBeTruthy()
     await fs.promises.stat(path.join(git.env['HOME'], '.gitconfig'))
 
     // Act
@@ -940,6 +960,7 @@ describe('git-auth-helper tests', () => {
 
     // Assert
     expect(git.env['HOME']).toBeUndefined()
+    expect(git.env['GIT_CONFIG_GLOBAL']).toBeUndefined()
     try {
       await fs.promises.stat(homeOverride)
       throw new Error(`Should have been deleted '${homeOverride}'`)

--- a/dist/index.js
+++ b/dist/index.js
@@ -35109,6 +35109,10 @@ class GitAuthHelper {
         // Override HOME
         info(`Temporarily overriding HOME='${this.temporaryHomePath}' before making global git config changes`);
         this.git.setEnvironmentVariable('HOME', this.temporaryHomePath);
+        // GIT_CONFIG_GLOBAL takes precedence over HOME when locating the global
+        // config file. Pin it to the temporary config so an inherited
+        // GIT_CONFIG_GLOBAL cannot redirect our global git config writes elsewhere.
+        this.git.setEnvironmentVariable('GIT_CONFIG_GLOBAL', newGitConfigPath);
         return newGitConfigPath;
     }
     async configureGlobalAuth() {
@@ -35183,8 +35187,9 @@ class GitAuthHelper {
     }
     async removeGlobalConfig() {
         if (this.temporaryHomePath?.length > 0) {
-            core_debug(`Unsetting HOME override`);
+            core_debug(`Unsetting HOME and GIT_CONFIG_GLOBAL overrides`);
             this.git.removeEnvironmentVariable('HOME');
+            this.git.removeEnvironmentVariable('GIT_CONFIG_GLOBAL');
             await rmRF(this.temporaryHomePath);
         }
     }

--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -122,6 +122,11 @@ class GitAuthHelper {
     )
     this.git.setEnvironmentVariable('HOME', this.temporaryHomePath)
 
+    // GIT_CONFIG_GLOBAL takes precedence over HOME when locating the global
+    // config file. Pin it to the temporary config so an inherited
+    // GIT_CONFIG_GLOBAL cannot redirect our global git config writes elsewhere.
+    this.git.setEnvironmentVariable('GIT_CONFIG_GLOBAL', newGitConfigPath)
+
     return newGitConfigPath
   }
 
@@ -237,8 +242,9 @@ class GitAuthHelper {
 
   async removeGlobalConfig(): Promise<void> {
     if (this.temporaryHomePath?.length > 0) {
-      core.debug(`Unsetting HOME override`)
+      core.debug(`Unsetting HOME and GIT_CONFIG_GLOBAL overrides`)
       this.git.removeEnvironmentVariable('HOME')
+      this.git.removeEnvironmentVariable('GIT_CONFIG_GLOBAL')
       await io.rmRF(this.temporaryHomePath)
     }
   }


### PR DESCRIPTION
## Problem

When a checkout sets up global auth (e.g. `submodules: true`), `configureTempGlobalConfig` does:

1. Copy `~/.gitconfig` into a temp dir and override **`HOME`** to point at it.
2. Write the auth token placeholder via `git config --global …`, expecting it to land in the temp config (because `HOME` now points there).
3. Read the temp config back and swap the placeholder for the real token (`replaceTokenPlaceholder`).

The catch: **`GIT_CONFIG_GLOBAL` overrides `HOME`** when git locates the global config file. So if the environment already has `GIT_CONFIG_GLOBAL` set, step 2 writes to *that* file instead of the temp config. Step 3 then reads the temp config, doesn't find the placeholder, and fails:

```
##[error]Unable to replace auth placeholder in /.../_temp/<uuid>/.gitconfig
```

checkout only ever overrides `HOME`, never `GIT_CONFIG_GLOBAL` — so a `GIT_CONFIG_GLOBAL` set by the workflow or runner (a common way to isolate git config per job on self-hosted runners) silently wins.

## Fix

Pin `GIT_CONFIG_GLOBAL` to the temporary config alongside the existing `HOME` override, and unset it again in `removeGlobalConfig`. Both env vars then point at the same temp file, so `--global` operations target it regardless of any inherited value. Backward compatible: older git that ignores `GIT_CONFIG_GLOBAL` still falls back to the `HOME` override (same file).

## How it works

`setEnvironmentVariable`/`removeEnvironmentVariable` don't change the process environment — they edit the `GitCommandManager`'s `gitEnv` map, which is overlaid on top of `process.env` each time checkout spawns a `git` subprocess:

```ts
const env = {}
for (const key of Object.keys(process.env)) { env[key] = process.env[key] }
for (const key of Object.keys(this.gitEnv)) { env[key] = this.gitEnv[key] } // overrides win
```

- The **`set`** in `configureTempGlobalConfig` forces `GIT_CONFIG_GLOBAL=<temp>/.gitconfig` for checkout's git commands, shadowing any inherited value — this is the fix.
- The **`remove`** in `removeGlobalConfig` is teardown that mirrors the existing `HOME` cleanup; the fix does not depend on it.

## Reproduction (real git 2.54)

Inherited `GIT_CONFIG_GLOBAL` set to a decoy file, simulating checkout's `git config --global` write then the temp-config read:

| | `--global` write lands in | placeholder in temp config | result |
|---|---|---|---|
| HOME override only (today) | the inherited file | absent | `Unable to replace auth placeholder` |
| HOME + `GIT_CONFIG_GLOBAL` pinned (this PR) | the temp config | present | replace succeeds |

## Scope

The `HOME`-only override predates v6 — `configureTempGlobalConfig` has the same shape in v4 and v5 — so this affects v4/v5/v6. The fix applies cleanly in each.

## Tests

- `configureGlobalAuth overrides GIT_CONFIG_GLOBAL` — asserts the override points at the temp config.
- `removeGlobalConfig removes override` — extended to assert `GIT_CONFIG_GLOBAL` is unset afterward.
- `dist/index.js` rebuilt via `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)