### PR TITLE
Disable automatic Git maintenance

### DIFF
--- a/__test__/git-command-manager.test.ts
+++ b/__test__/git-command-manager.test.ts
@@ -572,3 +572,39 @@ describe('git user-agent with orchestration ID', () => {
     )
   })
 })
+
+describe('automatic garbage collection configuration', () => {
+  beforeEach(() => {
+    mockFileExistsSync.mockReset()
+    mockDirectoryExistsSync.mockReset()
+    mockExec.mockImplementation((path: any, args: any, options: any) => {
+      if (args.includes('version')) {
+        options.listeners.stdout(Buffer.from('git version 2.54.0'))
+      }
+      return 0
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('disables maintenance and legacy garbage collection', async () => {
+    git = await commandManager.createCommandManager('test', false, false)
+
+    await expect(git.tryDisableAutomaticGarbageCollection()).resolves.toBe(
+      true
+    )
+
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.any(String),
+      ['config', '--local', 'maintenance.auto', 'false'],
+      expect.objectContaining({ignoreReturnCode: true})
+    )
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.any(String),
+      ['config', '--local', 'gc.auto', '0'],
+      expect.objectContaining({ignoreReturnCode: true})
+    )
+  })
+})

--- a/dist/index.js
+++ b/dist/index.js
@@ -35918,8 +35918,9 @@ class GitCommandManager {
         return output.exitCode === 0;
     }
     async tryDisableAutomaticGarbageCollection() {
-        const output = await this.execGit(['config', '--local', 'gc.auto', '0'], true);
-        return output.exitCode === 0;
+        const maintenanceOutput = await this.execGit(['config', '--local', 'maintenance.auto', 'false'], true);
+        const gcOutput = await this.execGit(['config', '--local', 'gc.auto', '0'], true);
+        return maintenanceOutput.exitCode === 0 && gcOutput.exitCode === 0;
     }
     async tryGetFetchUrl() {
         const output = await this.execGit(['config', '--local', '--get', 'remote.origin.url'], true);
@@ -41889,7 +41890,7 @@ async function getSource(settings) {
             startGroup('Fetching submodules');
             await git.submoduleSync(settings.nestedSubmodules);
             await git.submoduleUpdate(settings.fetchDepth, settings.nestedSubmodules);
-            await git.submoduleForeach('git config --local gc.auto 0', settings.nestedSubmodules);
+            await git.submoduleForeach('git config --local maintenance.auto false && git config --local gc.auto 0', settings.nestedSubmodules);
             endGroup();
             // Persist credentials
             if (settings.persistCredentials) {

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -517,11 +517,15 @@ class GitCommandManager {
   }
 
   async tryDisableAutomaticGarbageCollection(): Promise<boolean> {
-    const output = await this.execGit(
+    const maintenanceOutput = await this.execGit(
+      ['config', '--local', 'maintenance.auto', 'false'],
+      true
+    )
+    const gcOutput = await this.execGit(
       ['config', '--local', 'gc.auto', '0'],
       true
     )
-    return output.exitCode === 0
+    return maintenanceOutput.exitCode === 0 && gcOutput.exitCode === 0
   }
 
   async tryGetFetchUrl(): Promise<string> {

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -283,7 +283,7 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
       await git.submoduleSync(settings.nestedSubmodules)
       await git.submoduleUpdate(settings.fetchDepth, settings.nestedSubmodules)
       await git.submoduleForeach(
-        'git config --local gc.auto 0',
+        'git config --local maintenance.auto false && git config --local gc.auto 0',
         settings.nestedSubmodules
       )
       core.endGroup()


### PR DESCRIPTION
## Summary

- disable `maintenance.auto` as well as the legacy `gc.auto` on the primary checkout
- apply the same pair of settings to every checked-out submodule
- cover both configuration writes with a command-manager regression test
- regenerate the committed action bundle

Git 2.54's default background maintenance is no longer governed by `gc.auto`. Disabling both settings prevents an asynchronous maintenance run from mutating shallow metadata while checkout is deepening history.

Fixes #2437

## Validation

- `npm run format-check`
- `npm test` (129 passed)
- `npm run build`
- `git diff --check`

`npm run lint` is currently blocked in this Windows checkout by repository-wide pre-existing CRLF and TypeScript `.js`-import resolver findings, including files outside this change.
