### PR TITLE
escape values passed to --unset

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35913,7 +35913,7 @@ class GitCommandManager {
         else {
             args.push(globalConfig ? '--global' : '--local');
         }
-        args.push('--unset', configKey, configValue);
+        args.push('--unset', configKey, regexp_helper_escape(configValue));
         const output = await this.execGit(args, true);
         return output.exitCode === 0;
     }

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -510,7 +510,7 @@ class GitCommandManager {
     } else {
       args.push(globalConfig ? '--global' : '--local')
     }
-    args.push('--unset', configKey, configValue)
+    args.push('--unset', configKey, regexpHelper.escape(configValue))
 
     const output = await this.execGit(args, true)
     return output.exitCode === 0


### PR DESCRIPTION
Fixes https://github.com/actions/checkout/issues/2528 by escaping the value passed to `git config --unset`. This prevents Windows credential config paths from failing to match or producing invalid-pattern errors, leaving stale includeIf entries behind.